### PR TITLE
Fix issue with skipping AC devices in CCM15Device.py

### DIFF
--- a/ccm15/CCM15Device.py
+++ b/ccm15/CCM15Device.py
@@ -31,7 +31,8 @@ class CCM15Device:
         ac_index = 0
         for ac_name, ac_binary in data.items():
             if ac_binary == "-":
-                break
+                ac_index += 1
+                continue
             bytesarr = bytes.fromhex(ac_binary.strip(","))
             ac_slave = CCM15SlaveDevice(bytesarr)
             ac_data.devices[ac_index] = ac_slave


### PR DESCRIPTION
I tried to switch to the home assistant integration "ccm15", but found no entity on my device. So I did some debug, and found that my CCM15 status.xml is not starting from a0. Here is the example response. 

```
curl /status.xml

<?xml version="1.0" encoding="gb2312"?>
<response>
<a0>-</a0>
<a1>801000b0c00020,</a1>
<a2>801000b0b00021,</a2>
<a3>801000b0c00021,</a3>
<a4>801000b0c00020,</a4>
<a5>801000b0c00020,</a5>
<a6>-</a6>
<a7>-</a7>
<a8>-</a8>
<a9>-</a9>
<a10>-</a10>
...
```