### PR TITLE
BREAKING FIX:  async_set_state must has the old  ac_mode and fan_mode

### DIFF
--- a/ccm15/CCM15Device.py
+++ b/ccm15/CCM15Device.py
@@ -60,7 +60,7 @@ class CCM15Device:
             response = await client.get(url, timeout = self.timeout)
             return response.status_code in (httpx.codes.OK, httpx.codes.FOUND)
 
-    async def async_set_state(self, ac_index: int, state: str, value: int) -> bool:
+    async def async_set_state(self, ac_index: int, data) -> bool:
         """Set new target states."""
         ac_id: int = 2**ac_index
         url = BASE_URL.format(
@@ -70,10 +70,9 @@ class CCM15Device:
             + "?ac0="
             + str(ac_id)
             + "&ac1=0"
-            + "&"
-            + state
-            + "="
-            + str(value),
+            + "&mode=" + str(data.ac_mode)
+            +  "&fan=" + str(data.fan_mode)
+            + "&temp=" + str(data.temperature_setpoint)
         )
 
         return await self.async_send_state(url)


### PR DESCRIPTION
When I am cooling, all is OK
When I am heating, the orogin function is set only the new parameter, but the CCM15 want to receive the all settings of the current A/C.
We need to set them again and again, in every change (fan mode, ac mode, temperature).

So we forced to send all of the information. or it will freeze me and my wife in the rainy winter (true story).

     GET /ctrl.xml?....&ac0=2&ac1=0&mode=1&fan=0&temp=18&sw=0&ht=0 HTTP/1.1

