### PR TITLE
Fix non-contiguous slots and slaves >= 32 in CCM15Device

### DIFF
--- a/ccm15/CCM15Device.py
+++ b/ccm15/CCM15Device.py
@@ -23,19 +23,31 @@ class CCM15Device:
         return response.text
 
     async def _fetch_data(self) -> CCM15DeviceState:
-        """Get the current status of all AC devices."""
+        """Get the current status of all AC devices.
+
+        Slot numbers in the status.xml response are not guaranteed to be
+        contiguous (CCM15 can have empty slots before/between active units,
+        e.g. slaves 0-3 absent, 4-21 present). Use `continue` to skip empty
+        slots, and derive the device index from the XML key so the slot
+        number is preserved end-to-end and `async_set_state` builds the
+        correct slave bitmask.
+        """
         str_data = await self._fetch_xml_data()
         doc = xmltodict.parse(str_data)
         data = doc["response"]
         ac_data = CCM15DeviceState(devices={})
-        ac_index = 0
         for ac_name, ac_binary in data.items():
             if ac_binary == "-":
-                break
-            bytesarr = bytes.fromhex(ac_binary.strip(","))
-            ac_slave = CCM15SlaveDevice(bytesarr)
-            ac_data.devices[ac_index] = ac_slave
-            ac_index += 1
+                continue
+            try:
+                ac_index = int(str(ac_name).lstrip("aA"))
+            except ValueError:
+                continue
+            try:
+                bytesarr = bytes.fromhex(str(ac_binary).strip(","))
+            except ValueError:
+                continue
+            ac_data.devices[ac_index] = CCM15SlaveDevice(bytesarr)
         return ac_data
 
     async def get_status_async(self) -> CCM15DeviceState:
@@ -61,19 +73,29 @@ class CCM15Device:
             return response.status_code in (httpx.codes.OK, httpx.codes.FOUND)
 
     async def async_set_state(self, ac_index: int, data) -> bool:
-        """Set new target states."""
-        ac_id: int = 2**ac_index
+        """Set new target states.
+
+        Route the slave bitmask to ac0 for slots 0-31 and ac1 for slots
+        32-63. Previously all bits were placed in ac0, which silently
+        overflowed for slave indices >= 32.
+        """
+        if ac_index < 32:
+            ac0 = 2 ** ac_index
+            ac1 = 0
+        else:
+            ac0 = 0
+            ac1 = 2 ** (ac_index - 32)
         url = BASE_URL.format(
             self.host,
             self.port,
             CONF_URL_CTRL
             + "?ac0="
-            + str(ac_id)
-            + "&ac1=0"
+            + str(ac0)
+            + "&ac1="
+            + str(ac1)
             + "&mode=" + str(data.ac_mode)
             +  "&fan=" + str(data.fan_mode)
             + "&temp=" + str(data.temperature_setpoint)
         )
 
         return await self.async_send_state(url)
-

--- a/tests/test_ccm15.py
+++ b/tests/test_ccm15.py
@@ -2,39 +2,75 @@ import unittest
 from unittest.mock import patch, MagicMock
 from ccm15 import CCM15Device, CCM15DeviceState, CCM15SlaveDevice
 
+
 class TestCCM15(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.ccm = CCM15Device("localhost", 8000)
 
     @patch("httpx.AsyncClient.get")
     async def test_get_status_async(self, mock_get) -> None:
-        # Set up mock response
+        """Contiguous active slots starting at 0."""
         mock_response = MagicMock()
         mock_response.text = """
         <response>
-            <ac1>00000001020304</ac1>
-            <ac2>00000005060708</ac2>
+            <a0>00000001020304,</a0>
+            <a1>00000005060708,</a1>
         </response>
         """
         mock_get.return_value = mock_response
 
-        # Call method and check result
         state = await self.ccm.get_status_async()
         self.assertIsInstance(state, CCM15DeviceState)
-        self.assertEqual(len(state.devices), 2)
+        self.assertEqual(set(state.devices.keys()), {0, 1})
         self.assertIsInstance(state.devices[0], CCM15SlaveDevice)
         self.assertIsInstance(state.devices[1], CCM15SlaveDevice)
 
     @patch("httpx.AsyncClient.get")
-    async def test_async_set_state(self, mock_get):
-        # Set up mock response
+    async def test_get_status_async_noncontiguous(self, mock_get) -> None:
+        """Empty slots before and between active slots must not truncate parsing."""
+        mock_response = MagicMock()
+        mock_response.text = """
+        <response>
+            <a0>-</a0>
+            <a1>-</a1>
+            <a2>00000001020304,</a2>
+            <a3>-</a3>
+            <a4>00000005060708,</a4>
+        </response>
+        """
+        mock_get.return_value = mock_response
+
+        state = await self.ccm.get_status_async()
+        self.assertEqual(set(state.devices.keys()), {2, 4})
+
+    @patch("httpx.AsyncClient.get")
+    async def test_async_set_state_low_slot(self, mock_get):
+        """Slots 0-31 go into ac0, ac1 is 0."""
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_get.return_value = mock_response
 
-        # Call method and check result
-        result = await self.ccm.async_set_state(0, "state", 1)
-        self.assertTrue(result)
+        data = MagicMock(ac_mode=0, fan_mode=0, temperature_setpoint=24)
+        self.assertTrue(await self.ccm.async_set_state(4, data))
+
+        called_url = mock_get.call_args.args[0]
+        self.assertIn("ac0=16", called_url)
+        self.assertIn("ac1=0", called_url)
+
+    @patch("httpx.AsyncClient.get")
+    async def test_async_set_state_high_slot(self, mock_get):
+        """Slots 32-63 go into ac1, ac0 is 0."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        data = MagicMock(ac_mode=0, fan_mode=0, temperature_setpoint=24)
+        self.assertTrue(await self.ccm.async_set_state(40, data))
+
+        called_url = mock_get.call_args.args[0]
+        self.assertIn("ac0=0", called_url)
+        self.assertIn("ac1=256", called_url)  # 2 ** (40 - 32)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Two bugs in `CCM15Device.py`:

**1. `_fetch_data` exits on the first empty slot.**

```python
for ac_name, ac_binary in data.items():
    if ac_binary == "-":
        break
```

A CCM15 is not guaranteed to have active units at slots 0..N. Tested against a production install with `a0`-`a3` empty and `a4`-`a21` populated (18 units): the loop exits at `a0` and `devices` ends up empty. Downstream the Home Assistant integration loads as `state: loaded` with no entities and no error in the log, which is hard to diagnose.

Fix: `continue` on empty slots; derive `ac_index` from the XML key so `devices` is keyed by true slot number. Narrow `try/except` so a malformed payload can't crash the whole refresh.

**2. `async_set_state` always writes the bitmask to `ac0`.**

```python
ac_id: int = 2**ac_index
url = ... + "&ac0=" + str(ac_id) + "&ac1=0" + ...
```

Slots 32-63 belong in `ac1` per the controller's own `cmd_aclist()` in `midea.js`. `2**40` written to `ac0` overflows silently and the command targets the wrong unit (or nothing).

Fix: split across `ac0` (0-31) and `ac1` (32-63).

## Tests

Existing `test_get_status_async` used `<ac1>/<ac2>` tag names which do not match real CCM15 output (`<a0>..<a63>`). Fixed to use real names, added cases for non-contiguous slots and for slaves in the 32-63 range. All 8 tests pass locally.

## Compatibility

No API change. Installs with contiguous slots starting at 0 see the same keying as before (`ac_index` from the key equals the previous counter value). Existing downstream code keeps working.

## Verification

Live CCM15 (Midea OEM, 18 slaves at 4-21). Pre-patch: 0 devices decoded. Post-patch: 18 devices with correct `ac_mode`, `fan_mode`, `temperature_setpoint`, `temperature`, `error_code`. The `>= 32` bitmask fix is by inspection against `midea.js`; I don't have hardware in that range.