### PR TITLE
fix: update async_set_state test to current API

### DIFF
--- a/tests/test_ccm15.py
+++ b/tests/test_ccm15.py
@@ -33,7 +33,8 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
         mock_get.return_value = mock_response
 
         # Call method and check result
-        result = await self.ccm.async_set_state(0, "state", 1)
+        state = CCM15SlaveDevice(bytes.fromhex("00000041d2001a"))
+        result = await self.ccm.async_set_state(0, state)
         self.assertTrue(result)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
`tests/test_ccm15.py::test_async_set_state` was failing with:

```
TypeError: CCM15Device.async_set_state() takes 3 positional arguments but 4 were given
```

The `async_set_state` signature changed in #12 from `(ac_index, state, value)` to `(ac_index, data)`, where `data` is a `CCM15SlaveDevice` exposing `ac_mode`, `fan_mode`, and `temperature_setpoint`. The test was never updated and still called the old three-argument form.

## Fix
Construct a `CCM15SlaveDevice` from a sample byte buffer (same fixture style as `test_slave.py`) and pass it as `data`.

## Verification
`python -m pytest -q` → **6 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)