### PR TITLE
ci: run pytest on push and pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: pytest (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest
+
+      - name: Run unit tests
+        run: python -m pytest -q


### PR DESCRIPTION
## Summary
The repo has no CI that runs the unit tests. `main.yml` only builds and publishes on `v*` tags, and `release-please.yml` only manages releases — neither runs `pytest`. As a result, failing tests (e.g. the stale `async_set_state` signature fixed in #21, and the slot-handling bugs in #23) reached `main` and were only caught by running the suite locally.

## Change
Add a **Tests** workflow that runs `python -m pytest -q` on:
- every push to `main`
- every pull request

across Python **3.9-3.12** (`fail-fast: false` so all versions report).

It installs the package with `pip install -e .` (pulling in `httpx`, `xmltodict`, `aiohttp`) plus `pytest`. The async tests use `unittest.IsolatedAsyncioTestCase`, which pytest runs natively — no `pytest-asyncio` needed.

## Follow-up
Once merged, this can be made a **required status check** on `main` so PRs can't merge with red tests. Recommend landing this first, then rebasing the open fix PRs (#23) so their checks run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)