### PR TITLE
test: cover HTTP helpers and slave decode branches, gate coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install pytest
+          pip install pytest pytest-cov
 
-      - name: Run unit tests
-        run: python -m pytest -q
+      - name: Run unit tests with coverage
+        run: python -m pytest -q --cov=ccm15 --cov-branch --cov-report=term-missing --cov-fail-under=95

--- a/ccm15/CCM15Device.py
+++ b/ccm15/CCM15Device.py
@@ -41,7 +41,7 @@ class CCM15Device:
     async def get_status_async(self) -> CCM15DeviceState:
         return await self._fetch_data()
 
-    async def async_test_connection(self):  # pragma: no cover
+    async def async_test_connection(self):
         """Test the connection to the CCM15 device."""
         url = f"http://{self.host}:{self.port}/{CONF_URL_STATUS}"
         try:
@@ -54,7 +54,7 @@ class CCM15Device:
         except (aiohttp.ClientError, asyncio.TimeoutError):
             return False
 
-    async def async_send_state(self, url: str) -> bool:  # pragma: no cover
+    async def async_send_state(self, url: str) -> bool:
         """Send the url to set state to the ccm15 slave."""
         async with httpx.AsyncClient() as client:
             response = await client.get(url, timeout = self.timeout)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,78 @@
+"""Tests for the HTTP helpers on CCM15Device.
+
+These cover async_send_state (httpx) and async_test_connection (aiohttp),
+including their failure branches, which previously carried `# pragma: no
+cover` and were never exercised.
+"""
+import unittest
+from unittest.mock import patch, MagicMock
+
+import aiohttp
+import httpx
+
+from ccm15 import CCM15Device
+
+
+class _AsyncCM:
+    """Minimal async context manager yielding a fixed value."""
+
+    def __init__(self, value):
+        self._value = value
+
+    async def __aenter__(self):
+        return self._value
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
+class TestAsyncSendState(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.ccm = CCM15Device("localhost", 8000)
+
+    @patch("httpx.AsyncClient.get")
+    async def test_returns_true_on_ok(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=httpx.codes.OK)
+        self.assertTrue(await self.ccm.async_send_state("http://x/ctrl.xml"))
+
+    @patch("httpx.AsyncClient.get")
+    async def test_returns_true_on_found(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=httpx.codes.FOUND)
+        self.assertTrue(await self.ccm.async_send_state("http://x/ctrl.xml"))
+
+    @patch("httpx.AsyncClient.get")
+    async def test_returns_false_on_error_status(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=httpx.codes.INTERNAL_SERVER_ERROR)
+        self.assertFalse(await self.ccm.async_send_state("http://x/ctrl.xml"))
+
+
+class TestAsyncTestConnection(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.ccm = CCM15Device("localhost", 8000)
+
+    def _patch_session(self, *, status=None, get_side_effect=None):
+        """Patch aiohttp.ClientSession so `async with ... as session` yields a
+        mock whose .get(...) is itself an async CM yielding a response."""
+        session = MagicMock()
+        if get_side_effect is not None:
+            session.get = MagicMock(side_effect=get_side_effect)
+        else:
+            response = MagicMock(status=status)
+            session.get = MagicMock(return_value=_AsyncCM(response))
+        return patch("aiohttp.ClientSession", return_value=_AsyncCM(session))
+
+    async def test_returns_true_on_200(self):
+        with self._patch_session(status=200):
+            self.assertTrue(await self.ccm.async_test_connection())
+
+    async def test_returns_false_on_non_200(self):
+        with self._patch_session(status=500):
+            self.assertFalse(await self.ccm.async_test_connection())
+
+    async def test_returns_false_on_client_error(self):
+        with self._patch_session(get_side_effect=aiohttp.ClientError()):
+            self.assertFalse(await self.ccm.async_test_connection())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_slave.py
+++ b/tests/test_slave.py
@@ -32,5 +32,37 @@ class TestCCM15SlaveDevice(unittest.TestCase):
         self.assertEqual(0, device.locked_cool_temperature)
         self.assertEqual(0, device.locked_heat_temperature)
 
+    def test_all_fields_locked_and_negative_temp(self) -> None:
+        """Decode every field with locks active and a sub-zero room temp.
+
+        Byte layout (celsius): A8 74 16 8E 8A 78 C8
+        b5 = 0x78 keeps the locked cool/heat temps and sets the fan/remote
+        locks; b6 = 0xC8 (200) decodes as a signed -56.
+        """
+        device = CCM15SlaveDevice(bytes.fromhex("a874168e8a78c8"))
+        self.assertTrue(device.is_celsius)
+        self.assertEqual(21, device.locked_cool_temperature)
+        self.assertEqual(20, device.locked_heat_temperature)
+        self.assertEqual(3, device.locked_wind)
+        self.assertEqual(2, device.locked_ac_mode)
+        self.assertEqual(5, device.error_code)
+        self.assertEqual(3, device.ac_mode)
+        self.assertEqual(4, device.fan_mode)
+        self.assertTrue(device.is_ac_mode_locked)
+        self.assertEqual(17, device.temperature_setpoint)
+        self.assertTrue(device.is_swing_on)
+        self.assertTrue(device.fan_locked)
+        self.assertTrue(device.is_remote_locked)
+        self.assertEqual(-56, device.temperature)
+
+    def test_locked_temps_cleared_when_flags_off(self) -> None:
+        """b5 = 0x00 clears the locked cool/heat temps and the lock flags."""
+        device = CCM15SlaveDevice(bytes.fromhex("a874168e8a0048"))
+        self.assertEqual(0, device.locked_cool_temperature)
+        self.assertEqual(0, device.locked_heat_temperature)
+        self.assertFalse(device.fan_locked)
+        self.assertFalse(device.is_remote_locked)
+        self.assertEqual(72, device.temperature)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
Follow-up to the CI workflow (#24): the previous **99% line coverage was misleading**. `async_send_state` and `async_test_connection` were excluded with `# pragma: no cover`, and `CCM15SlaveDevice`'s bit-decoding only ran a couple of sample bytes, so most branches and all the HTTP error paths were untested.

## Changes
- **Remove the two `# pragma: no cover` markers** so the HTTP helpers are actually measured.
- **`tests/test_http.py` (new)** — covers `async_send_state` (OK / FOUND / error status) and `async_test_connection` (200, non-200, `aiohttp.ClientError`). Put in a new file to avoid conflicts with the in-flight #23 / #17.
- **`tests/test_slave.py`** — decode tests for locks, error code, locked wind, **negative (signed) room temperature**, and the locked-temp clear branch.
- **`test.yml`** — switch CI to **branch** coverage with a **95% gate** (`--cov-branch --cov-fail-under=95`) so coverage can't silently regress.

## Coverage
Before (line only, pragmas hiding two methods): "99%".
After (branch coverage, nothing excluded): **98%** — `14 passed`.

```
Name                        Stmts   Miss Branch BrPart  Cover
ccm15\CCM15Device.py           53      1      6      1    97%   (line 34)
ccm15\CCM15DeviceState.py       5      0      0      0   100%
ccm15\CCM15SlaveDevice.py      37      0      8      0   100%
ccm15\__init__.py               4      0      0      0   100%
TOTAL                          99      1     14      1    98%
```

The single remaining uncovered line (34) is the `_fetch_data` `break` — fixed and covered by the non-contiguous-slots PR #23. Once that merges, coverage reaches ~100% and the gate can be raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)