### PR TITLE
docs: note that this library is consumed by Home Assistant core

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,37 @@ Rules:
 - **If a PR title doesn't match this grammar, release-please silently ignores
   it** and no release is cut.
 
+## Downstream consumer: Home Assistant core
+
+**This library is a published dependency of Home Assistant core.** The `ccm15`
+integration at `homeassistant/components/ccm15/` imports it directly:
+
+- `coordinator.py` constructs `CCM15Device(host, port, timeout)` and calls
+  `get_status_async()` and `async_set_state(ac_index, data)`.
+- `climate.py` reads `CCM15SlaveDevice` fields (`temperature`,
+  `temperature_setpoint`, `ac_mode`, `fan_mode`, `is_swing_on`, `error_code`).
+- The version is pinned in `manifest.json` (`requirements: ["py_ccm15==X.Y.Z"]`)
+  and mirrored into HA's generated `requirements_all.txt` /
+  `requirements_test_all.txt`. `@ocalvo` is the codeowner.
+
+Implications when changing this repo:
+
+- **The public API is a contract.** Renaming/removing `CCM15Device`,
+  `CCM15SlaveDevice`, `CCM15DeviceState`, their fields, or changing the
+  `async_set_state` / `get_status_async` signatures **breaks HA core**. Treat
+  such changes as `feat!`/`fix!` (major bump) and pair them with a
+  homeassistant/core PR.
+- **HA does not auto-upgrade.** Fixing a bug here only reaches HA users after a
+  release **and** a follow-up homeassistant/core PR bumping the pin in
+  `manifest.json` (target the `dev` branch). A fix sitting in a release nobody
+  bumped to is invisible to HA users — e.g. issues reported against the
+  integration may already be fixed in a newer release than HA pins.
+- **Behavior decoded here, commanded in HA.** `CCM15SlaveDevice` decodes raw
+  controller status; HA's `const.py` maps `HVACMode` <-> int command codes. A
+  mode/fan-encoding mismatch between status and command surfaces as wrong
+  behavior in HA (see issue #15), so keep the decode semantics stable and
+  documented.
+
 ## Versioning
 
 Do **not** hand-edit the version in `pyproject.toml` — release-please owns it.


### PR DESCRIPTION
## Summary
Adds a `CLAUDE.md` section recording that this library is a **published dependency of Home Assistant core** (`homeassistant/components/ccm15/`, pinned in `manifest.json`, `@ocalvo` codeowner).

It captures the implications surfaced while investigating #15:
- The public API (`CCM15Device`, `CCM15SlaveDevice` fields, `async_set_state`/`get_status_async`) is a contract — breaking it requires a paired homeassistant/core PR and a major bump.
- Fixes only reach HA users after a release **and** a core `manifest.json` bump (target `dev`), so integration bug reports may already be fixed in a newer release than HA pins.
- Status is decoded here; commands are mapped in HA's `const.py`, so encoding mismatches show up as integration bugs (#15).

Docs-only (`docs:` → no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)