### PR TITLE
ci: publish to PyPI from release-please run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,15 @@
-name: Build and Publish to PyPI
+name: Publish to PyPI (manual)
 
+# Automated publishing happens inside release-please.yml on every release-please
+# release. This workflow is a manual fallback for (re)publishing a specific tag
+# that was never published — e.g. a tag created before automated publishing was
+# wired into the release-please run.
 on:
-  push:
-    tags:
-      - 'v*'  # Triggers only on tags like v0.1.0, v1.0.1
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag or ref to build and publish (e.g. v0.2.2)'
+        required: true
 
 permissions:
   contents: read
@@ -16,6 +22,8 @@ jobs:
     steps:
     - name: Checkout source code
       uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref }}
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,45 @@ jobs:
   release-please:
     name: Run release-please
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Build and Publish to PyPI
+    needs: release-please
+    # A tag created by release-please uses the default GITHUB_TOKEN, and GitHub
+    # does not trigger other workflows from GITHUB_TOKEN-created events. So a
+    # separate tag-triggered workflow never fires. Instead we publish from this
+    # same run, gated on release-please having actually cut a release.
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload dist/*


### PR DESCRIPTION
## Problem

`v0.2.2` was tagged and released on GitHub but **never published to PyPI**, so downstream consumers (Home Assistant core) cannot pin it.

Root cause: the `Build and Publish to PyPI` workflow (`main.yml`) triggered on `push: tags: v*`, but release-please creates the tag using the default `GITHUB_TOKEN`. GitHub **does not trigger workflows from `GITHUB_TOKEN`-created events** (recursion guard), so the publish workflow never ran for any release-please tag.

## Fix

- **`release-please.yml`** — add a `publish` job in the same workflow run, gated on `release_created`. Because it runs inside the already-triggered release-please run (kicked off by the human merge of the release PR), no cross-workflow trigger is needed, so the `GITHUB_TOKEN` limitation does not apply.
- **`main.yml`** — converted from a (dead) tag trigger into a manual `workflow_dispatch` fallback that takes a `ref` input, for (re)publishing a specific tag such as the already-tagged `v0.2.2`.

## Follow-up after merge

1. Run the **Publish to PyPI (manual)** workflow against `v0.2.2` to backfill the missing PyPI release.
2. Bump the `py_ccm15` pin in home-assistant/core `manifest.json` to `0.2.2`.

No release is cut by this PR (`ci:` type is ignored by release-please).