### PR TITLE
test: guard that set_state always sends mode+fan+temp (issue #15)

### DIFF
--- a/tests/test_ccm15.py
+++ b/tests/test_ccm15.py
@@ -87,6 +87,29 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
         self.assertIn("ac0=0", called_url)
         self.assertIn("ac1=256", called_url)  # 2 ** (40 - 32)
 
+    @patch("httpx.AsyncClient.get")
+    async def test_async_set_state_sends_full_state(self, mock_get):
+        """Regression test for #15.
+
+        The CCM15 treats every ctrl.xml write as the complete desired state and
+        resets any omitted field to its default (which lands on COOL). So a
+        single set must always carry mode, fan AND temp together, using the
+        caller's current values. Here the unit is in HEAT (mode=1) with a
+        non-default fan; all three must appear in the command, otherwise the
+        controller would revert to COOL.
+        """
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        data = MagicMock(ac_mode=1, fan_mode=2, temperature_setpoint=26)
+        self.assertTrue(await self.ccm.async_set_state(0, data))
+
+        called_url = mock_get.call_args.args[0]
+        self.assertIn("mode=1", called_url)  # HEAT preserved, not reset to COOL
+        self.assertIn("fan=2", called_url)
+        self.assertIn("temp=26", called_url)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Regression guard for #15 ("Mode reverts to Cool when setting temperature in mode Heat").

### Background
The CCM15 controller treats every `ctrl.xml` write as the **complete** desired state — any omitted field is reset to its default, which lands on **COOL**. The original library sent only the single changed parameter, so a temperature change dropped `mode`/`fan` and the unit reverted to COOL/23. [#12](https://github.com/ocalvo/py-ccm15/pull/12) fixed this by always sending the full `mode`+`fan`+`temp` triple, and Home Assistant shipped it via [core#134719](https://github.com/home-assistant/core/pull/134719).

### The gap
The existing `async_set_state` tests only assert the `ac0`/`ac1` slot routing, and they use `ac_mode=0` (COOL — the default), so they would **not** catch a regression that drops `mode`/`fan`. A future refactor could silently reintroduce #15.

### Change
Add `test_async_set_state_sends_full_state`: sets the unit to **HEAT** (`mode=1`) with a non-default fan and asserts `mode=1`, `fan=2`, and `temp=26` all appear in the command — i.e. the full state is sent and HEAT is not reset to COOL.

### Verification
`python -m pytest` → **18 passed**, branch coverage **100%** (gate is 95%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)