### PR TITLE
fix: tolerate transient CCM15 dropouts and report per-device data age

### DIFF
--- a/ccm15/CCM15Device.py
+++ b/ccm15/CCM15Device.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import time
 import httpx
 import xmltodict
 import aiohttp
@@ -9,12 +12,23 @@ BASE_URL = "http://{0}:{1}/{2}"
 CONF_URL_STATUS = "status.xml"
 CONF_URL_CTRL = "ctrl.xml"
 DEFAULT_TIMEOUT = 10
+DEFAULT_STATE_TTL = 300
 
 class CCM15Device:
-    def __init__(self, host: str, port: int, timeout = DEFAULT_TIMEOUT):
+    def __init__(self, host: str, port: int, timeout = DEFAULT_TIMEOUT,
+                 state_ttl = DEFAULT_STATE_TTL):
         self.host = host
         self.port = port
         self.timeout = timeout
+        # The CCM15 is a flaky embedded bridge: status.xml periodically times
+        # out or returns a degraded body (empty, or every slot "-") for up to a
+        # minute at a time, even while every AC is online. Cache the last read
+        # that actually decoded devices and serve it for up to `state_ttl`
+        # seconds so a transient dropout does not flap every entity to
+        # unavailable. Set state_ttl to 0 to disable caching.
+        self.state_ttl = state_ttl
+        self._last_state = None
+        self._last_good_monotonic = None
 
     async def _fetch_xml_data(self) -> str:
         url = BASE_URL.format(self.host, self.port, CONF_URL_STATUS)
@@ -50,8 +64,42 @@ class CCM15Device:
             ac_data.devices[ac_index] = CCM15SlaveDevice(bytesarr)
         return ac_data
 
+    def _fresh_cached_state(self) -> CCM15DeviceState | None:
+        """Return the last good state if it is still within the TTL, else None."""
+        if (
+            self.state_ttl
+            and self._last_state is not None
+            and self._last_good_monotonic is not None
+            and (time.monotonic() - self._last_good_monotonic) < self.state_ttl
+        ):
+            return self._last_state
+        return None
+
     async def get_status_async(self) -> CCM15DeviceState:
-        return await self._fetch_data()
+        """Return the current device state, tolerating transient dropouts.
+
+        A poll that raises (timeout/connection error) or decodes to zero
+        devices is treated as a transient dropout: the last state that did
+        decode devices is returned instead, as long as it is younger than
+        `state_ttl`. Once the cache ages past the TTL the real failure surfaces
+        (the exception propagates, or an empty state is returned) so a device
+        that is genuinely offline does eventually go unavailable.
+        """
+        try:
+            state = await self._fetch_data()
+        except Exception:
+            cached = self._fresh_cached_state()
+            if cached is not None:
+                return cached
+            raise
+
+        if state.devices:
+            self._last_state = state
+            self._last_good_monotonic = time.monotonic()
+            return state
+
+        cached = self._fresh_cached_state()
+        return cached if cached is not None else state
 
     async def async_test_connection(self):
         """Test the connection to the CCM15 device."""

--- a/ccm15/CCM15Device.py
+++ b/ccm15/CCM15Device.py
@@ -65,14 +65,21 @@ class CCM15Device:
         return ac_data
 
     def _fresh_cached_state(self) -> CCM15DeviceState | None:
-        """Return the last good state if it is still within the TTL, else None."""
+        """Return the last good state if it is still within the TTL, else None.
+
+        Stamps every cached device's `age` with how many seconds old the data
+        is, so a consumer can tell a cached read from a live one per device.
+        """
         if (
             self.state_ttl
             and self._last_state is not None
             and self._last_good_monotonic is not None
-            and (time.monotonic() - self._last_good_monotonic) < self.state_ttl
         ):
-            return self._last_state
+            age = time.monotonic() - self._last_good_monotonic
+            if age < self.state_ttl:
+                for device in self._last_state.devices.values():
+                    device.age = age
+                return self._last_state
         return None
 
     async def get_status_async(self) -> CCM15DeviceState:

--- a/ccm15/CCM15SlaveDevice.py
+++ b/ccm15/CCM15SlaveDevice.py
@@ -8,6 +8,12 @@ class CCM15SlaveDevice:
 
     def __init__(self, bytesarr: bytes) -> None:
         """Initialize the slave device."""
+        # Seconds since this device's data was actually read from the
+        # controller. 0.0 for a live read; > 0 when served from the last-good
+        # cache during a transient dropout (set by
+        # CCM15Device.get_status_async). Lets a consumer such as Home Assistant
+        # expose a "data is N seconds old" attribute per entity.
+        self.age: float = 0.0
         self.is_celsius = True
         buf = bytesarr[0]
         if (buf >> 0) & 1:

--- a/tests/test_ccm15.py
+++ b/tests/test_ccm15.py
@@ -1,5 +1,8 @@
 import unittest
 from unittest.mock import patch, MagicMock
+
+import httpx
+
 from ccm15 import CCM15Device, CCM15DeviceState, CCM15SlaveDevice
 
 
@@ -58,6 +61,58 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
 
         state = await self.ccm.get_status_async()
         self.assertEqual(set(state.devices.keys()), {0})
+
+    @patch("httpx.AsyncClient.get")
+    async def test_empty_response_serves_cached_state(self, mock_get) -> None:
+        """A transient all-'-' body returns the last good state, not empty."""
+        good = MagicMock()
+        good.text = "<response><a0>00000001020304,</a0></response>"
+        empty = MagicMock()
+        empty.text = "<response><a0>-</a0></response>"
+        mock_get.side_effect = [good, empty]
+
+        first = await self.ccm.get_status_async()
+        self.assertEqual(set(first.devices.keys()), {0})
+        second = await self.ccm.get_status_async()
+        self.assertIs(second, first)  # served from cache, identical object
+
+    @patch("httpx.AsyncClient.get")
+    async def test_exception_serves_cached_state(self, mock_get) -> None:
+        """A transient fetch error returns the last good state, not a raise."""
+        good = MagicMock()
+        good.text = "<response><a0>00000001020304,</a0></response>"
+        mock_get.side_effect = [good, httpx.ConnectTimeout("boom")]
+
+        first = await self.ccm.get_status_async()
+        second = await self.ccm.get_status_async()
+        self.assertIs(second, first)
+
+    @patch("httpx.AsyncClient.get")
+    async def test_cache_expires_after_ttl(self, mock_get) -> None:
+        """Past the TTL the real failure surfaces (exception propagates)."""
+        ccm = CCM15Device("localhost", 8000, state_ttl=300)
+        good = MagicMock()
+        good.text = "<response><a0>00000001020304,</a0></response>"
+        mock_get.side_effect = [good, httpx.ConnectTimeout("boom")]
+
+        with patch("ccm15.CCM15Device.time.monotonic", side_effect=[0.0, 301.0]):
+            await ccm.get_status_async()
+            with self.assertRaises(httpx.ConnectTimeout):
+                await ccm.get_status_async()
+
+    @patch("httpx.AsyncClient.get")
+    async def test_ttl_zero_disables_cache(self, mock_get) -> None:
+        """state_ttl=0 opts out: empty responses return empty state."""
+        ccm = CCM15Device("localhost", 8000, state_ttl=0)
+        good = MagicMock()
+        good.text = "<response><a0>00000001020304,</a0></response>"
+        empty = MagicMock()
+        empty.text = "<response><a0>-</a0></response>"
+        mock_get.side_effect = [good, empty]
+
+        await ccm.get_status_async()
+        second = await ccm.get_status_async()
+        self.assertEqual(second.devices, {})
 
     @patch("httpx.AsyncClient.get")
     async def test_async_set_state_low_slot(self, mock_get):

--- a/tests/test_ccm15.py
+++ b/tests/test_ccm15.py
@@ -73,8 +73,10 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
 
         first = await self.ccm.get_status_async()
         self.assertEqual(set(first.devices.keys()), {0})
+        self.assertEqual(first.devices[0].age, 0.0)  # live read
         second = await self.ccm.get_status_async()
         self.assertIs(second, first)  # served from cache, identical object
+        self.assertGreater(second.devices[0].age, 0.0)  # stamped as stale
 
     @patch("httpx.AsyncClient.get")
     async def test_exception_serves_cached_state(self, mock_get) -> None:

--- a/tests/test_ccm15.py
+++ b/tests/test_ccm15.py
@@ -95,10 +95,11 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
         good.text = "<response><a0>00000001020304,</a0></response>"
         mock_get.side_effect = [good, httpx.ConnectTimeout("boom")]
 
-        with patch("ccm15.CCM15Device.time.monotonic", side_effect=[0.0, 301.0]):
+        await ccm.get_status_async()
+        # Backdate the last good read past the TTL window.
+        ccm._last_good_monotonic -= 301
+        with self.assertRaises(httpx.ConnectTimeout):
             await ccm.get_status_async()
-            with self.assertRaises(httpx.ConnectTimeout):
-                await ccm.get_status_async()
 
     @patch("httpx.AsyncClient.get")
     async def test_ttl_zero_disables_cache(self, mock_get) -> None:


### PR DESCRIPTION
## Problem

Fixes #33. The CCM15 is a flaky embedded RS485↔HTTP bridge. Roughly every 3 minutes it either times out / resets the `status.xml` request, or returns a degraded body (empty, or every slot `-`) for up to ~1 minute — even though every AC is online. Both cases collapsed to "all devices unavailable" in Home Assistant, through two paths:

| Failure | Path | HA result |
|---|---|---|
| Timeout / connection reset | `httpx` raises out of `get_status_async` | coordinator `last_update_success=False` → all entities unavailable |
| Empty / all-`-` body | parses fine → `CCM15DeviceState(devices={})` | coordinator "succeeds" with zero devices → each entity unavailable |

This is distinct from #16 (PR #23), which fixed *permanently* empty leading slots; #33 is *transient* whole-device dropouts.

## Changes

**1. Last-good-state caching (`fix`, #33).** `CCM15Device` caches the last read that decoded ≥1 device. Any poll that **raises** or **decodes to zero devices** returns that cached state instead, as long as it is younger than `state_ttl` (new optional constructor arg, default **300 s**; `0` disables). Once the cache ages past the TTL the real failure resurfaces, so a genuinely-offline device still goes unavailable.

**2. Per-device data age (`feat`).** Each `CCM15SlaveDevice` now carries an `age` attribute — `0.0` for a live read, or the seconds the data has been cached when served during a dropout. HA can later surface this as a per-entity "data is N seconds old" attribute and distinguish cached readings from live ones.

Both are **additive to the public API** — no signature/field removals or renames. `state_ttl=0` reproduces the previous behavior exactly.

## Tests

22 passing, 100% coverage. New cases: cache served on degraded body, cache served on exception, cache expires past TTL (failure resurfaces), `state_ttl=0` opt-out, and per-device `age` (0 live / >0 cached).

## Downstream note

Per `CLAUDE.md`, HA does not auto-upgrade: this reaches users only after a release **and** a follow-up homeassistant/core PR bumping the `py_ccm15` pin in `manifest.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)