### PR TITLE
docs: require HA bump PRs to list the full version-delta changelog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,21 @@ Implications when changing this repo:
   behavior in HA (see issue #15), so keep the decode semantics stable and
   documented.
 
+### homeassistant/core bump PRs must list every change in the version delta
+
+A bump PR usually skips several releases (the pin lags the latest PyPI
+version), so its description must enumerate **all** changes between the
+previously pinned version and the new one — not just the headline fix that
+motivated the bump. HA reviewers and changelog readers see only the PR
+description; an undocumented fix in an intermediate release is effectively
+invisible.
+
+When writing the bump PR body, walk `CHANGELOG.md` from the old pin
+(exclusive) to the new version (inclusive) and list each `feat`/`fix`/`perf`
+entry with its upstream PR/issue link. Skip `docs`/`chore`/`ci`/`test`
+entries (no runtime effect). Example for a `0.1.2` → `0.2.4` bump: cover the
+relevant entries from `0.2.0`, `0.2.1`, `0.2.2`, `0.2.3`, and `0.2.4`.
+
 ## Versioning
 
 Do **not** hand-edit the version in `pyproject.toml` — release-please owns it.


### PR DESCRIPTION
## Summary

Adds a rule to the Home Assistant section of `CLAUDE.md`: a `homeassistant/core` PR that bumps the `py_ccm15` pin must enumerate **every** change between the previously pinned version and the new one (walking `CHANGELOG.md`), not just the headline fix. Bump PRs typically skip several releases, and HA reviewers/changelog readers only see the PR description.

`docs:` only — no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)