### PR TITLE
ci: stop docs/ci/test commits from triggering releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,20 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-component-in-tag": false,
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "deps", "section": "Dependencies" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "docs", "section": "Documentation", "hidden": true },
+    { "type": "style", "section": "Styles", "hidden": true },
+    { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+    { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true },
+    { "type": "build", "section": "Build System", "hidden": true },
+    { "type": "ci", "section": "Continuous Integration", "hidden": true }
+  ],
   "packages": {
     ".": {
       "release-type": "python",


### PR DESCRIPTION
## Problem

release-please cut release **0.2.3** from a window that contained only `docs` (#27, #30), `ci` (#29, #31), and `test` (#32) commits — no `feat`/`fix`. That contradicts the type/bump table in `CLAUDE.md` ("docs/ci/test = no release") and means an innocuous docs PR triggers a publish to PyPI.

## Cause

With no `changelog-sections` configured, this `release-please-action` version leaves `docs`/`ci`/`test` **visible** in the changelog, and a *visible* changelog section implicitly bumps the patch version (googleapis/release-please#2638). The 0.2.3 changelog shows a "Documentation" section, confirming docs was visible and therefore release-triggering.

## Fix

Pin `changelog-sections` explicitly:
- **Visible / release-triggering:** `feat`, `fix`, `perf`, `deps`, `revert`.
- **Hidden / non-releasing:** `docs`, `style`, `chore`, `refactor`, `test`, `build`, `ci`.

release-please reads the config from `main` at evaluation time, so once this merges, the new rules apply to subsequent merges (including the pending docs PR #36).

## Type

`ci:` — config-only, no release. Under the new rules this very commit is a hidden type, so merging it must not cut a release. (If a release PR unexpectedly appears, that's the signal `hidden` doesn't fully gate releases and we escalate; note the PyPI publish is in any case gated on a release PR actually being merged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)