### PR TITLE
feat: accept an injected httpx.AsyncClient and manage its lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ asyncio.run(main())
 - Python 3.7+
 - httpx>=0.24.1
 - xmltodict>=0.13.0
-- aiohttp>=3.8.5
 
 ## Documentation
 

--- a/ccm15/CCM15Device.py
+++ b/ccm15/CCM15Device.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import time
 import httpx
 import xmltodict
-import aiohttp
-import asyncio
 from .CCM15DeviceState import CCM15DeviceState
 from .CCM15SlaveDevice import CCM15SlaveDevice
 
@@ -16,7 +14,8 @@ DEFAULT_STATE_TTL = 300
 
 class CCM15Device:
     def __init__(self, host: str, port: int, timeout = DEFAULT_TIMEOUT,
-                 state_ttl = DEFAULT_STATE_TTL):
+                 state_ttl = DEFAULT_STATE_TTL,
+                 client: "httpx.AsyncClient | None" = None):
         self.host = host
         self.port = port
         self.timeout = timeout
@@ -29,11 +28,42 @@ class CCM15Device:
         self.state_ttl = state_ttl
         self._last_state = None
         self._last_good_monotonic = None
+        # An httpx.AsyncClient can be passed in to avoid the library
+        # constructing one inside an asyncio loop. Constructing an
+        # AsyncClient synchronously loads the certifi CA bundle, which
+        # asyncio detects as a blocking I/O call. Callers running on an
+        # event loop (such as Home Assistant) should pass in a client that
+        # was built off the loop.
+        self._client = client
+        # Only a client we build ourselves is ours to close. An injected
+        # client is owned by the caller and must outlive this object, so
+        # aclose() must never touch it.
+        self._owns_client = client is None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient()
+        return self._client
+
+    async def aclose(self) -> None:
+        """Close the httpx client, but only if this object created it.
+
+        An injected client is left untouched; its owner is responsible for
+        closing it. Safe to call more than once.
+        """
+        if self._client is not None and self._owns_client:
+            await self._client.aclose()
+            self._client = None
+
+    async def __aenter__(self) -> "CCM15Device":
+        return self
+
+    async def __aexit__(self, *exc_info) -> None:
+        await self.aclose()
 
     async def _fetch_xml_data(self) -> str:
         url = BASE_URL.format(self.host, self.port, CONF_URL_STATUS)
-        async with httpx.AsyncClient() as client:
-            response = await client.get(url, timeout=self.timeout)
+        response = await self._get_client().get(url, timeout=self.timeout)
         return response.text
 
     async def _fetch_data(self) -> CCM15DeviceState:
@@ -108,24 +138,19 @@ class CCM15Device:
         cached = self._fresh_cached_state()
         return cached if cached is not None else state
 
-    async def async_test_connection(self):
+    async def async_test_connection(self) -> bool:
         """Test the connection to the CCM15 device."""
-        url = f"http://{self.host}:{self.port}/{CONF_URL_STATUS}"
+        url = BASE_URL.format(self.host, self.port, CONF_URL_STATUS)
         try:
-            async with aiohttp.ClientSession() as session, session.get(
-                url, timeout = self.timeout
-            ) as response:
-                if response.status == 200:
-                    return True
-                return False
-        except (aiohttp.ClientError, asyncio.TimeoutError):
+            response = await self._get_client().get(url, timeout=self.timeout)
+        except httpx.RequestError:
             return False
+        return response.status_code == 200
 
     async def async_send_state(self, url: str) -> bool:
         """Send the url to set state to the ccm15 slave."""
-        async with httpx.AsyncClient() as client:
-            response = await client.get(url, timeout = self.timeout)
-            return response.status_code in (httpx.codes.OK, httpx.codes.FOUND)
+        response = await self._get_client().get(url, timeout=self.timeout)
+        return response.status_code in (httpx.codes.OK, httpx.codes.FOUND)
 
     async def async_set_state(self, ac_index: int, data) -> bool:
         """Set new target states.
@@ -156,4 +181,3 @@ class CCM15Device:
         )
 
         return await self.async_send_state(url)
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,7 @@ authors = [
 ]
 dependencies = [
     "httpx>=0.24.1",
-    "xmltodict>=0.13.0",
-    "aiohttp>=3.8.5"
+    "xmltodict>=0.13.0"
 ]
 requires-python = ">=3.7"
 keywords = ["Midea", "CCM15", "data converter"]

--- a/tests/test_ccm15.py
+++ b/tests/test_ccm15.py
@@ -74,9 +74,13 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
         first = await self.ccm.get_status_async()
         self.assertEqual(set(first.devices.keys()), {0})
         self.assertEqual(first.devices[0].age, 0.0)  # live read
+        # Age the last good read deterministically: back-to-back calls can land
+        # inside a single time.monotonic() tick (coarse on some platforms), so
+        # don't rely on wall-clock elapsing to prove the cached read is stamped.
+        self.ccm._last_good_monotonic -= 5
         second = await self.ccm.get_status_async()
         self.assertIs(second, first)  # served from cache, identical object
-        self.assertGreater(second.devices[0].age, 0.0)  # stamped as stale
+        self.assertGreaterEqual(second.devices[0].age, 5.0)  # stamped as stale
 
     @patch("httpx.AsyncClient.get")
     async def test_exception_serves_cached_state(self, mock_get) -> None:
@@ -167,6 +171,46 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
         self.assertIn("mode=1", called_url)  # HEAT preserved, not reset to COOL
         self.assertIn("fan=2", called_url)
         self.assertIn("temp=26", called_url)
+
+    async def test_uses_injected_client_when_provided(self) -> None:
+        """A client passed to the constructor is reused instead of building a new one."""
+        injected = MagicMock(spec=httpx.AsyncClient)
+        device = CCM15Device("localhost", 8000, client=injected)
+        self.assertIs(device._get_client(), injected)
+
+    async def test_builds_client_when_not_provided(self) -> None:
+        """Standalone callers can still use the library without an injected client."""
+        device = CCM15Device("localhost", 8000)
+        client = device._get_client()
+        self.assertIsInstance(client, httpx.AsyncClient)
+        # Lazy creation is cached for the lifetime of the device.
+        self.assertIs(device._get_client(), client)
+
+    async def test_aclose_closes_self_built_client(self) -> None:
+        """A client the library built is closed (no leak) on aclose()."""
+        device = CCM15Device("localhost", 8000)
+        built = device._get_client()
+        await device.aclose()
+        self.assertTrue(built.is_closed)
+        self.assertIsNone(device._client)
+        # Idempotent: a second close is a no-op, not an error.
+        await device.aclose()
+
+    async def test_aclose_leaves_injected_client_open(self) -> None:
+        """An injected client is owned by the caller and must not be closed."""
+        injected = httpx.AsyncClient()
+        device = CCM15Device("localhost", 8000, client=injected)
+        await device.aclose()
+        self.assertFalse(injected.is_closed)
+        self.assertIs(device._client, injected)
+        await injected.aclose()
+
+    async def test_context_manager_closes_self_built_client(self) -> None:
+        """`async with CCM15Device(...)` closes a self-built client on exit."""
+        async with CCM15Device("localhost", 8000) as device:
+            built = device._get_client()
+            self.assertFalse(built.is_closed)
+        self.assertTrue(built.is_closed)
 
 
 if __name__ == "__main__":

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,29 +1,15 @@
 """Tests for the HTTP helpers on CCM15Device.
 
-These cover async_send_state (httpx) and async_test_connection (aiohttp),
+These cover async_send_state and async_test_connection (both httpx),
 including their failure branches, which previously carried `# pragma: no
 cover` and were never exercised.
 """
 import unittest
 from unittest.mock import patch, MagicMock
 
-import aiohttp
 import httpx
 
 from ccm15 import CCM15Device
-
-
-class _AsyncCM:
-    """Minimal async context manager yielding a fixed value."""
-
-    def __init__(self, value):
-        self._value = value
-
-    async def __aenter__(self):
-        return self._value
-
-    async def __aexit__(self, *exc_info):
-        return False
 
 
 class TestAsyncSendState(unittest.IsolatedAsyncioTestCase):
@@ -50,28 +36,20 @@ class TestAsyncTestConnection(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.ccm = CCM15Device("localhost", 8000)
 
-    def _patch_session(self, *, status=None, get_side_effect=None):
-        """Patch aiohttp.ClientSession so `async with ... as session` yields a
-        mock whose .get(...) is itself an async CM yielding a response."""
-        session = MagicMock()
-        if get_side_effect is not None:
-            session.get = MagicMock(side_effect=get_side_effect)
-        else:
-            response = MagicMock(status=status)
-            session.get = MagicMock(return_value=_AsyncCM(response))
-        return patch("aiohttp.ClientSession", return_value=_AsyncCM(session))
+    @patch("httpx.AsyncClient.get")
+    async def test_returns_true_on_200(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=200)
+        self.assertTrue(await self.ccm.async_test_connection())
 
-    async def test_returns_true_on_200(self):
-        with self._patch_session(status=200):
-            self.assertTrue(await self.ccm.async_test_connection())
+    @patch("httpx.AsyncClient.get")
+    async def test_returns_false_on_non_200(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=500)
+        self.assertFalse(await self.ccm.async_test_connection())
 
-    async def test_returns_false_on_non_200(self):
-        with self._patch_session(status=500):
-            self.assertFalse(await self.ccm.async_test_connection())
-
-    async def test_returns_false_on_client_error(self):
-        with self._patch_session(get_side_effect=aiohttp.ClientError()):
-            self.assertFalse(await self.ccm.async_test_connection())
+    @patch("httpx.AsyncClient.get")
+    async def test_returns_false_on_request_error(self, mock_get):
+        mock_get.side_effect = httpx.ConnectError("boom")
+        self.assertFalse(await self.ccm.async_test_connection())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Split out of #17 — the Home Assistant blocking-call fix.**

Constructing `httpx.AsyncClient()` does blocking I/O (it loads the certifi CA bundle and builds an `SSLContext`). The library currently does this *on the event loop* inside `_fetch_xml_data`/`async_send_state`, which trips Home Assistant's blocking-call detector and aborts integration setup.

This PR lets the caller inject a client:

- New optional `client` kwarg (appended to the signature → non-breaking). HA can pass its shared, off-loop `httpx.AsyncClient` (`homeassistant.helpers.httpx_client.get_async_client`); standalone callers fall back to a lazily-built one.
- `aclose()` + async-context-manager support that closes **only** a self-built client; an injected client is owned by the caller and left open.
- `async_test_connection` migrated off `aiohttp` onto the same httpx client; **`aiohttp` dependency dropped**.

Tests cover injected vs. self-built reuse, `aclose` ownership, and the context manager. Non-breaking (`feat`).

### Part of a 3-way split
- `password` / authentication — #17.
- **This PR** — injectable httpx client.
- `sw` / `ht` control params — separate PR, gated on #39.

Downstream: unblocks home-assistant/core#173645.

Original work by @Alexa-RR.