### PR TITLE
feat: send swing (sw) and ht control parameters in set_state

### DIFF
--- a/ccm15/CCM15Device.py
+++ b/ccm15/CCM15Device.py
@@ -142,6 +142,18 @@ class CCM15Device:
         else:
             ac0 = 0
             ac1 = 2 ** (ac_index - 32)
+        # sw is the swing-louver flag; it mirrors CCM15SlaveDevice.is_swing_on
+        # (decoded from byte 4, bit 1) so a command round-trips with the
+        # decoded state. 1 = swing on, 0 = off.
+        sw = 1 if getattr(data, "is_swing_on", False) else 0
+        # ht is sent as a constant 0 because that is what the controller's own
+        # web UI sends. Its exact meaning is NOT decoded from status anywhere in
+        # this library, so a hardcoded 0 is unverified: the CCM15 treats every
+        # ctrl.xml write as the full desired state (see #15), so if ht is an
+        # aux-heat flag this would force it off on every command. Confirming
+        # what ht is and whether it must be derived is tracked in
+        # https://github.com/ocalvo/py-ccm15/issues/39 and gates merging this.
+        ht = 0
         url = BASE_URL.format(
             self.host,
             self.port,
@@ -153,6 +165,8 @@ class CCM15Device:
             + "&mode=" + str(data.ac_mode)
             +  "&fan=" + str(data.fan_mode)
             + "&temp=" + str(data.temperature_setpoint)
+            + "&sw=" + str(sw)
+            + "&ht=" + str(ht)
         )
 
         return await self.async_send_state(url)

--- a/tests/test_ccm15.py
+++ b/tests/test_ccm15.py
@@ -168,6 +168,33 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
         self.assertIn("fan=2", called_url)
         self.assertIn("temp=26", called_url)
 
+    @patch("httpx.AsyncClient.get")
+    async def test_set_state_swing_on_sends_sw_and_ht(self, mock_get):
+        """is_swing_on=True maps to sw=1; ht=0 is sent (see issue #39)."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        data = MagicMock(ac_mode=0, fan_mode=4, temperature_setpoint=22, is_swing_on=True)
+        await self.ccm.async_set_state(1, data)
+
+        called_url = mock_get.call_args.args[0]
+        self.assertIn("sw=1", called_url)
+        self.assertIn("ht=0", called_url)
+
+    @patch("httpx.AsyncClient.get")
+    async def test_set_state_swing_off_sends_sw_zero(self, mock_get):
+        """is_swing_on=False maps to sw=0."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        data = MagicMock(ac_mode=1, fan_mode=2, temperature_setpoint=18, is_swing_on=False)
+        await self.ccm.async_set_state(0, data)
+
+        called_url = mock_get.call_args.args[0]
+        self.assertIn("sw=0", called_url)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Split out of #17 — draft, gated on #39.**

Adds two control parameters to `async_set_state`:

- **`sw`** (swing) — derived from `data.is_swing_on`, round-trips with the decoded `CCM15SlaveDevice.is_swing_on`. This part is sound and makes the swing louver controllable.
- **`ht`** — sent as a constant `0` to match the controller's web UI. **Its meaning is not decoded anywhere in the library**, so the hardcoded `0` is unverified. Because the CCM15 treats every `ctrl.xml` write as the complete desired state (#15), a constant `ht=0` could force whatever `ht` controls off on every command.

Per our rule against undocumented hardcoded constants, this **must not merge** until `ht` is understood (from the upstream `midea.js` / houselabs reference) and either documented or derived.

Tracked in #39 — kept as a **draft** until that's resolved.

Original work by @Alexa-RR.