### PR TITLE
feat: opt-in swing control via a TriState desired value

### DIFF
--- a/ccm15/CCM15Device.py
+++ b/ccm15/CCM15Device.py
@@ -5,6 +5,7 @@ import httpx
 import xmltodict
 from .CCM15DeviceState import CCM15DeviceState
 from .CCM15SlaveDevice import CCM15SlaveDevice
+from .TriState import TriState
 
 BASE_URL = "http://{0}:{1}/{2}"
 CONF_URL_STATUS = "status.xml"
@@ -187,5 +188,11 @@ class CCM15Device:
             +  "&fan=" + str(data.fan_mode)
             + "&temp=" + str(data.temperature_setpoint)
         )
+        # Opt-in swing: only emit `sw` when the caller set a desired value.
+        # UNSET (the default) leaves the command byte-for-byte unchanged, so
+        # firmware that does not accept `sw` is unaffected.
+        desired_swing = getattr(data, "desired_swing", TriState.UNSET)
+        if isinstance(desired_swing, TriState) and desired_swing.is_set:
+            url += "&sw=" + str(desired_swing.value)
 
         return await self.async_send_state(url)

--- a/ccm15/CCM15SlaveDevice.py
+++ b/ccm15/CCM15SlaveDevice.py
@@ -2,6 +2,8 @@
 from dataclasses import dataclass
 from enum import Enum
 
+from .TriState import TriState
+
 @dataclass
 class CCM15SlaveDevice:
     """Data retrieved from a CCM15 slave device."""
@@ -41,7 +43,13 @@ class CCM15SlaveDevice:
             self.temperature_setpoint += 62
             self.locked_cool_temperature += 62
             self.locked_heat_temperature += 62
+        # Current swing state decoded from status (read-only view for display).
         self.is_swing_on: bool = (buf >> 1) & 1 != 0
+        # Desired swing to write on the next control command. Distinct from the
+        # decoded current state above: it defaults to UNSET (omit `sw` from the
+        # command) and is only changed by an explicit caller, so polling never
+        # causes `sw` to start being sent. See `desired_swing`.
+        self._desired_swing: TriState = TriState.UNSET
 
         buf = bytesarr[5]
         if ((buf >> 3) & 1) == 0:
@@ -53,3 +61,17 @@ class CCM15SlaveDevice:
 
         buf = bytesarr[6]
         self.temperature: int = buf if buf < 128 else buf - 256
+
+    @property
+    def desired_swing(self) -> TriState:
+        """Swing value to write on the next control command.
+
+        ``UNSET`` (the default) omits the ``sw`` parameter from the command;
+        ``ON``/``OFF`` send it explicitly. Setting this is how a caller opts in
+        to swing control on firmware known to accept it.
+        """
+        return self._desired_swing
+
+    @desired_swing.setter
+    def desired_swing(self, value: TriState) -> None:
+        self._desired_swing = value

--- a/ccm15/TriState.py
+++ b/ccm15/TriState.py
@@ -1,0 +1,39 @@
+"""A three-valued state for optional control parameters."""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class TriState(Enum):
+    """Three-valued state for an optional ctrl.xml command parameter.
+
+    The CCM15 treats every control write as the complete desired state, and not
+    every firmware accepts every optional parameter (e.g. the electric-heater
+    `ht` flag). So these parameters are opt-in:
+
+    - ``UNSET`` — leave the parameter out of the command entirely. This is the
+      safe default; the wire output is byte-for-byte what it was before the
+      parameter existed.
+    - ``OFF`` / ``ON`` — send the parameter explicitly as ``0`` / ``1``.
+
+    This is the *desired* value a caller wants written. It is deliberately
+    distinct from the decoded current state (e.g. ``CCM15SlaveDevice.is_swing_on``):
+    polling the device never changes a desired value, so a poll can never cause
+    an opt-in parameter to start being sent.
+    """
+
+    UNSET = None
+    OFF = 0
+    ON = 1
+
+    @classmethod
+    def from_bool(cls, value: bool | None) -> "TriState":
+        """Map ``None``/``True``/``False`` to ``UNSET``/``ON``/``OFF``."""
+        if value is None:
+            return cls.UNSET
+        return cls.ON if value else cls.OFF
+
+    @property
+    def is_set(self) -> bool:
+        """Whether the parameter should be written (i.e. not ``UNSET``)."""
+        return self is not TriState.UNSET

--- a/ccm15/__init__.py
+++ b/ccm15/__init__.py
@@ -3,6 +3,7 @@
 from .CCM15Device import CCM15Device
 from .CCM15DeviceState import CCM15DeviceState
 from .CCM15SlaveDevice import CCM15SlaveDevice
+from .TriState import TriState
 
-__all__ = ['CCM15Device', 'CCM15DeviceState', 'CCM15SlaveDevice']
+__all__ = ['CCM15Device', 'CCM15DeviceState', 'CCM15SlaveDevice', 'TriState']
 

--- a/tests/test_ccm15.py
+++ b/tests/test_ccm15.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, MagicMock
 
 import httpx
 
-from ccm15 import CCM15Device, CCM15DeviceState, CCM15SlaveDevice
+from ccm15 import CCM15Device, CCM15DeviceState, CCM15SlaveDevice, TriState
 
 
 class TestCCM15(unittest.IsolatedAsyncioTestCase):
@@ -240,6 +240,65 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
             built = device._get_client()
             self.assertFalse(built.is_closed)
         self.assertTrue(built.is_closed)
+
+    @patch("httpx.AsyncClient.get")
+    async def test_set_state_omits_swing_by_default(self, mock_get):
+        """A freshly decoded device has desired_swing UNSET, so no sw is sent."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        data = CCM15SlaveDevice(bytes.fromhex("00000001020304"))
+        self.assertIs(data.desired_swing, TriState.UNSET)
+        await self.ccm.async_set_state(0, data)
+
+        called_url = mock_get.call_args.args[0]
+        self.assertNotIn("sw=", called_url)
+
+    @patch("httpx.AsyncClient.get")
+    async def test_set_state_sends_swing_on_when_desired(self, mock_get):
+        """Setting desired_swing=ON emits sw=1."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        data = CCM15SlaveDevice(bytes.fromhex("00000001020304"))
+        data.desired_swing = TriState.ON
+        await self.ccm.async_set_state(1, data)
+
+        called_url = mock_get.call_args.args[0]
+        self.assertIn("sw=1", called_url)
+
+    @patch("httpx.AsyncClient.get")
+    async def test_set_state_sends_swing_off_when_desired(self, mock_get):
+        """Setting desired_swing=OFF emits sw=0."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        data = CCM15SlaveDevice(bytes.fromhex("00000001020304"))
+        data.desired_swing = TriState.OFF
+        await self.ccm.async_set_state(0, data)
+
+        called_url = mock_get.call_args.args[0]
+        self.assertIn("sw=0", called_url)
+
+
+class TestTriState(unittest.TestCase):
+    def test_from_bool(self):
+        self.assertIs(TriState.from_bool(None), TriState.UNSET)
+        self.assertIs(TriState.from_bool(True), TriState.ON)
+        self.assertIs(TriState.from_bool(False), TriState.OFF)
+
+    def test_is_set(self):
+        self.assertFalse(TriState.UNSET.is_set)
+        self.assertTrue(TriState.ON.is_set)
+        self.assertTrue(TriState.OFF.is_set)
+
+    def test_values(self):
+        # Wire values: ON -> "1", OFF -> "0".
+        self.assertEqual(str(TriState.ON.value), "1")
+        self.assertEqual(str(TriState.OFF.value), "0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Opt-in swing control via a tri-state desired value.**

Adds a `TriState` type (`UNSET` / `OFF` / `ON`) and a settable `desired_swing` property on `CCM15SlaveDevice`, kept separate from the decoded read-only `is_swing_on` (current state, for display):

- `async_set_state` emits `&sw=` **only** when `desired_swing` is set (`ON`/`OFF`).
- The default `UNSET` leaves the control URL **byte-for-byte unchanged**, so firmware that doesn't accept `sw` is unaffected, and a status poll never flips a desired value — so polling can never cause `sw` to start being sent.

This makes swing strictly opt-in: a caller (Home Assistant's swing setter) sets `data.desired_swing = TriState.ON/OFF` only on devices known to accept it.

Non-breaking (`feat`): `TriState` and `desired_swing` are additive; `is_swing_on` and the `async_set_state` signature are unchanged. Tests cover default-omitted, ON, OFF, and the `TriState` helpers.

The electric-heater (`ht`) parameter follows the exact same opt-in pattern in a **separate** PR, so it can be enabled independently once verified on real hardware.

Original work by @Alexa-RR, reworked as opt-in.