### PR TITLE
feat: opt-in electric heater (ht) via a TriState desired value

### DIFF
--- a/ccm15/CCM15Device.py
+++ b/ccm15/CCM15Device.py
@@ -194,5 +194,11 @@ class CCM15Device:
         desired_swing = getattr(data, "desired_swing", TriState.UNSET)
         if isinstance(desired_swing, TriState) and desired_swing.is_set:
             url += "&sw=" + str(desired_swing.value)
+        # Opt-in electric heater: same contract as swing. UNSET omits `ht`, so
+        # firmware that does not accept the electric-heater parameter is
+        # unaffected and polling never causes `ht` to start being sent.
+        desired_heater = getattr(data, "desired_heater", TriState.UNSET)
+        if isinstance(desired_heater, TriState) and desired_heater.is_set:
+            url += "&ht=" + str(desired_heater.value)
 
         return await self.async_send_state(url)

--- a/ccm15/CCM15SlaveDevice.py
+++ b/ccm15/CCM15SlaveDevice.py
@@ -45,11 +45,17 @@ class CCM15SlaveDevice:
             self.locked_heat_temperature += 62
         # Current swing state decoded from status (read-only view for display).
         self.is_swing_on: bool = (buf >> 1) & 1 != 0
+        # Current electric-heater state decoded from status (byte 4, bit 0),
+        # per the controller's own midea.js. Read-only view for display.
+        self.is_heater_on: bool = (buf >> 0) & 1 != 0
         # Desired swing to write on the next control command. Distinct from the
         # decoded current state above: it defaults to UNSET (omit `sw` from the
         # command) and is only changed by an explicit caller, so polling never
         # causes `sw` to start being sent. See `desired_swing`.
         self._desired_swing: TriState = TriState.UNSET
+        # Desired electric-heater state to write on the next control command.
+        # Same opt-in contract as desired_swing: UNSET omits `ht` entirely.
+        self._desired_heater: TriState = TriState.UNSET
 
         buf = bytesarr[5]
         if ((buf >> 3) & 1) == 0:
@@ -75,3 +81,18 @@ class CCM15SlaveDevice:
     @desired_swing.setter
     def desired_swing(self, value: TriState) -> None:
         self._desired_swing = value
+
+    @property
+    def desired_heater(self) -> TriState:
+        """Electric-heater value to write on the next control command.
+
+        ``UNSET`` (the default) omits the ``ht`` parameter from the command;
+        ``ON``/``OFF`` send it explicitly. Like ``desired_swing``, this is
+        opt-in because not every firmware accepts ``ht`` and the controller
+        treats each write as the complete desired state.
+        """
+        return self._desired_heater
+
+    @desired_heater.setter
+    def desired_heater(self, value: TriState) -> None:
+        self._desired_heater = value

--- a/tests/test_ccm15.py
+++ b/tests/test_ccm15.py
@@ -283,6 +283,58 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
         called_url = mock_get.call_args.args[0]
         self.assertIn("sw=0", called_url)
 
+    @patch("httpx.AsyncClient.get")
+    async def test_set_state_omits_heater_by_default(self, mock_get):
+        """A freshly decoded device has desired_heater UNSET, so no ht is sent."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        data = CCM15SlaveDevice(bytes.fromhex("00000001020304"))
+        self.assertIs(data.desired_heater, TriState.UNSET)
+        await self.ccm.async_set_state(0, data)
+
+        called_url = mock_get.call_args.args[0]
+        self.assertNotIn("ht=", called_url)
+
+    @patch("httpx.AsyncClient.get")
+    async def test_set_state_sends_heater_on_when_desired(self, mock_get):
+        """Setting desired_heater=ON emits ht=1, independent of swing."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        data = CCM15SlaveDevice(bytes.fromhex("00000001020304"))
+        data.desired_heater = TriState.ON
+        await self.ccm.async_set_state(1, data)
+
+        called_url = mock_get.call_args.args[0]
+        self.assertIn("ht=1", called_url)
+        self.assertNotIn("sw=", called_url)  # heater is independent of swing
+
+    @patch("httpx.AsyncClient.get")
+    async def test_set_state_sends_heater_off_when_desired(self, mock_get):
+        """Setting desired_heater=OFF emits ht=0."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        data = CCM15SlaveDevice(bytes.fromhex("00000001020304"))
+        data.desired_heater = TriState.OFF
+        await self.ccm.async_set_state(0, data)
+
+        called_url = mock_get.call_args.args[0]
+        self.assertIn("ht=0", called_url)
+
+
+class TestHeaterDecode(unittest.TestCase):
+    def test_is_heater_on_decoded_from_byte4_bit0(self):
+        # byte 4 bit 0 set -> heater on; clear -> off. Other bytes arbitrary.
+        on = CCM15SlaveDevice(bytes.fromhex("00000000010000"))
+        self.assertTrue(on.is_heater_on)
+        off = CCM15SlaveDevice(bytes.fromhex("00000000000000"))
+        self.assertFalse(off.is_heater_on)
+
 
 class TestTriState(unittest.TestCase):
     def test_from_bool(self):


### PR DESCRIPTION
**Opt-in electric heater (`ht`), built on the same `TriState` pattern as swing (#43, shipped in 0.5.0).**

Adds the electric auxiliary-heater control as a strictly opt-in parameter:

- **`CCM15SlaveDevice.is_heater_on`** — read-only current state, decoded from status byte 4 bit 0 (per the controller's own `midea.js`, captured from a real device — see #39).
- **`desired_heater`** — settable `TriState` property (default `UNSET`), mirroring `desired_swing`. `async_set_state` emits `&ht=` **only** when it's set; `UNSET` leaves the control URL byte-for-byte unchanged.
- Heater is **independent of swing** — separate desired value, so each is enabled on its own.

### Why opt-in
We can't assume every CCM15 firmware accepts `ht`, and electric aux-heat is *optional hardware*, not a universal feature. The CCM15 also treats every `ctrl.xml` write as the complete desired state (#15), so an unconditionally-sent `ht` would be asserted on every command and could break controllers that don't support it. Defaulting to `UNSET` means existing clients are unaffected and a status poll never causes `ht` to start being sent — the library stays passive until a caller explicitly opts in. Closes #39.

### Downstream (Home Assistant)
Aux/electric heat is no longer a climate feature in HA core (`ClimateEntityFeature.AUX_HEAT` was removed), so this surfaces as a **separate `switch` entity**, created only for devices that have a heater: `is_on` reads `is_heater_on`; `turn_on`/`turn_off` set `desired_heater = TriState.ON/OFF` and call `async_set_state`. No climate-entity change.

Non-breaking (`feat`): `is_heater_on` and `desired_heater` are additive; `async_set_state`'s signature is unchanged. Full suite green (39 tests).

Original work by @Alexa-RR (the `is_heater_on` decode + `midea.js` capture), reworked to the opt-in `TriState` pattern.