### PR TITLE
chore: point repository URLs at HomeOps after org transfer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ Link the GitHub compare view rather than copying the changelog text — it is
 self-updating and lets reviewers see every commit:
 
 ```
-[`v0.1.2...v0.2.4`](https://github.com/ocalvo/py-ccm15/compare/v0.1.2...v0.2.4)
+[`v0.1.2...v0.2.4`](https://github.com/HomeOps/py-ccm15/compare/v0.1.2...v0.2.4)
 ```
 
 (both `v<old-pin>` and `v<new-version>` are real tags release-please pushes).

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ asyncio.run(main())
 
 ## Documentation
 
-For full API reference and advanced usage, visit the [GitHub repository](https://github.com/ocalvo/py-ccm15).
+For full API reference and advanced usage, visit the [GitHub repository](https://github.com/HomeOps/py-ccm15).
 
 ## Protocol
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,5 +21,7 @@ license-files = ["LICENSE"]
 
 
 [project.urls]
-Homepage = "https://github.com/ocalvo/py-ccm15"
+Homepage = "https://github.com/HomeOps/py-ccm15"
+Repository = "https://github.com/HomeOps/py-ccm15"
+Changelog = "https://github.com/HomeOps/py-ccm15/blob/main/CHANGELOG.md"
 


### PR DESCRIPTION
Follow-up to the org transfer (`ocalvo/py-ccm15` → `HomeOps/py-ccm15`). Points in-repo references at the new org:

- `pyproject.toml` `[project.urls]`: `Homepage` → HomeOps, and add `Repository` + `Changelog`.
- README "GitHub repository" link → HomeOps.
- `CLAUDE.md` bump-PR compare-link example → HomeOps.

`CHANGELOG.md` is intentionally left untouched — it's release-please-generated history; the old `ocalvo` links redirect, and future entries pick up the new org automatically. No duplicate workflow to remove (already gone; only `release-please.yml` + `test.yml` remain).

Note: this is a `chore`, so release-please won't cut a release for it — the updated `Homepage` won't show on PyPI until the next `feat`/`fix` release (or a forced release). The change is cosmetic; old metadata links redirect in the meantime.