### PR TITLE
docs: confirm byte 6 current temperature is reported in the display unit

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -109,18 +109,18 @@ understood.
 |------|-------|---------|
 | 0–7 | `temperature` | Current room temperature, **signed** 8-bit (`value` if `< 128`, else `value − 256`). |
 
-> **Fahrenheit and the current temperature.** Unlike the setpoint and lock
-> setpoints, byte 6 is decoded **as-is — no `+62` offset is applied in
-> Fahrenheit mode**. This matches every known implementation: the original
+> **Fahrenheit and the current temperature.** Byte 6 is decoded **as-is — no
+> `+62` offset is applied in Fahrenheit mode**, and that is correct: the
+> controller emits the current temperature directly in the **active display
+> unit**, so a Fahrenheit-configured device already reports the Fahrenheit value
+> (e.g. `72`) in byte 6. This was confirmed on a real unit: switching the
+> hand/remote controller to Fahrenheit changes byte 6 to report Fahrenheit. The
+> `+62` offset applies only to the 5-bit setpoint *code* (and the lock
+> setpoints), which need it to land in the Fahrenheit display range; byte 6 is
+> already a full degree value, so it needs none. (The original
 > [houselabs](https://github.com/houselabs/home-assistant-mideaccm) decode and
 > [daxingplay](https://github.com/daxingplay/home-assistant-midea-ccm15) both
-> offset only `settemp`/`ctl`/`htl` and leave `temp` raw, and all of them
-> hardcode the reported unit to Celsius. Whether the controller emits byte 6 in
-> the active **display unit** (so a Fahrenheit-configured device would report
-> e.g. `72`) or **always in Celsius** has **not** been confirmed against a
-> live Fahrenheit-configured controller — no source resolves it, because none of
-> the reference implementations actually handle the Fahrenheit display case.
-> Treat the unit of byte 6 on a Fahrenheit device as *unverified*.
+> leave `temp` raw, matching this.)
 
 ---
 


### PR DESCRIPTION
## Summary

Updates the byte-6 (current temperature) note in `PROTOCOL.md` from *unverified*
to **confirmed**. The maintainer verified on a real CCM15: switching the
hand/remote controller to Fahrenheit makes byte 6 report the Fahrenheit value
directly.

This resolves the open question left by #52 — the controller emits the current
temperature in the **active display unit**, so decoding byte 6 raw (no `+62`) is
correct. The `+62` offset applies only to the 5-bit setpoint *code* and the lock
setpoints (which need it to reach the Fahrenheit display range); byte 6 is
already a full degree value and needs none.

Docs-only; no code or runtime change. Confirms the behavior relied on by the
Home Assistant fix in home-assistant/core#173788.

🤖 Generated with [Claude Code](https://claude.com/claude-code)