### PR TITLE
feat!: obfuscate password and return CCM15ReturnCode from writes

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -133,7 +133,7 @@ lands on COOL). A single write must therefore always carry the mode, fan and
 temperature it wants to keep — see the regression behavior in issue #15.
 
 ```
-http://<host>:<port>/ctrl.xml?[pwd=<pwd>&]ac0=<mask>&ac1=<mask>&mode=<m>&fan=<f>&temp=<t>[&sw=<0|1>][&ht=<0|1>]
+http://<host>:<port>/ctrl.xml?[pwd=<obf>&utsxxx=<nonce>&]ac0=<mask>&ac1=<mask>&mode=<m>&fan=<f>&temp=<t>[&sw=<0|1>][&ht=<0|1>]
 ```
 
 | Param | Required | Meaning |
@@ -143,7 +143,8 @@ http://<host>:<port>/ctrl.xml?[pwd=<pwd>&]ac0=<mask>&ac1=<mask>&mode=<m>&fan=<f>
 | `mode` | yes | Target HVAC mode — see **Mode codes**. |
 | `fan` | yes | Target fan speed — see **Fan codes**. |
 | `temp` | yes | Target temperature setpoint. |
-| `pwd` | optional | 6-digit device password. Some firmwares reject control writes unless it is supplied; omitted otherwise. |
+| `pwd` | optional | **Obfuscated** device password — *not* the value the user configured. Some firmwares reject control writes unless it is supplied. See **Password** below. |
+| `utsxxx` | optional | Per-request nonce sent alongside `pwd`: current time in milliseconds modulo `1000`. See **Password**. |
 | `sw` | optional | Swing: `1` on, `0` off. **Opt-in** (see below). |
 | `ht` | optional | Electric auxiliary heater: `1` on, `0` off. **Opt-in** (see below). |
 
@@ -169,6 +170,55 @@ from the *desired* value a caller wants to write (`desired_swing`,
 `desired_heater`, of type `TriState` — `UNSET` / `OFF` / `ON`). `UNSET` (the
 default) leaves the parameter out entirely, so a poll never causes it to start
 being sent.
+
+### Password (`pwd` / `utsxxx`)
+
+The `pwd` value on the wire is **not** the password the user configures on the
+controller's settings page. The controller's web UI obfuscates it in
+`pwdstr()`:
+
+```js
+// from a captured midea.js
+function pwdstr() {
+    var ts = (new Date()).valueOf();
+    var p  = parseInt(pwd);
+    p ^= 0x56789;      // XOR with a fixed magic key
+    p >>>= 0;          // cast to unsigned 32-bit
+    return 'pwd=' + p + '&utsxxx=' + (ts % 1000);
+}
+```
+
+So the transform is:
+
+```
+pwd_on_wire = (configured_password XOR 0x56789) & 0xFFFFFFFF
+utsxxx      = milliseconds_since_epoch % 1000
+```
+
+The factory-default password `123456` therefore goes on the wire as
+`pwd=296393` (`0x1E240 ^ 0x56789 = 0x485C9 = 296393`). A consumer must apply
+this transform itself: a user can only reasonably know their *configured*
+value. This library does it internally — callers pass the configured numeric
+password and the library emits the obfuscated `pwd` plus the `utsxxx` nonce.
+
+The magic key `0x56789` and the `utsxxx` shape are **not publicly documented
+anywhere**; they come solely from a `midea.js` capture (see **Credits**). Only
+status reads are unauthenticated — which is why polling works without a password
+even on firmwares that require it for writes.
+
+### Response codes (`<ret>`)
+
+A `ctrl.xml` response carries a `<ret>` status element. The controller's web UI
+(`check_password()`) treats one value specially:
+
+| `<ret>` | Meaning |
+|---------|---------|
+| `250` | **Wrong password** — the write was rejected. The web UI re-prompts for the password. |
+| other / absent | The command was accepted. |
+
+This library surfaces the outcome as a `CCM15ReturnCode`
+(`OK` / `WRONG_PASSWORD` / `CONNECTION_ERROR`) rather than a bare boolean, so a
+consumer can distinguish a bad password from a transport failure.
 
 ### Mode codes (`mode=` / `ac_mode`)
 
@@ -202,7 +252,10 @@ known implementation, so its meaning has not been confirmed.)*
   from a live CCM15 controller and traced the protocol to document the
   swing (`sw`, status byte 4 bit 1) and **electric-heater** (`ht`, status byte 4
   bit 0) parameters, including the control-URL semantics. The heater bit and the
-  `sw`/`ht` command documentation here are her work.
+  `sw`/`ht` command documentation here are her work. She also reverse-engineered
+  the **password obfuscation** (`pwdstr()` — the `0x56789` XOR key, the unsigned
+  32-bit cast, and the `utsxxx` nonce) and the **`<ret>` response codes**
+  (`250` = wrong password); none of these are documented anywhere else.
 - **[houselabs/home-assistant-mideaccm](https://github.com/houselabs/home-assistant-mideaccm)**
   (originally authored by Chao Shen) — the original reverse-engineering of the
   `status.xml` byte layout and the HVAC/fan mode mappings.

--- a/ccm15/CCM15Device.py
+++ b/ccm15/CCM15Device.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 import time
 import httpx
 import xmltodict
@@ -8,24 +7,18 @@ from .CCM15DeviceState import CCM15DeviceState
 from .CCM15ReturnCode import CCM15ReturnCode
 from .CCM15SlaveDevice import CCM15SlaveDevice
 from .TriState import TriState
+from .const import (
+    BASE_URL,
+    CONF_URL_CTRL,
+    CONF_URL_STATUS,
+    DEFAULT_STATE_TTL,
+    DEFAULT_TIMEOUT,
+    PASSWORD_MASK,
+    PASSWORD_XOR_KEY,
+    RET_PATTERN,
+    UTSXXX_MODULO,
+)
 
-BASE_URL = "http://{0}:{1}/{2}"
-CONF_URL_STATUS = "status.xml"
-CONF_URL_CTRL = "ctrl.xml"
-DEFAULT_TIMEOUT = 10
-DEFAULT_STATE_TTL = 300
-
-# Password obfuscation, mirroring the controller's own pwdstr() in midea.js.
-# The on-wire `pwd` value is the configured numeric password XORed with a fixed
-# magic key and cast to an unsigned 32-bit integer; a per-request `utsxxx`
-# nonce (milliseconds modulo 1000) is appended. These constants are otherwise
-# undocumented and come from a midea.js capture (see PROTOCOL.md / Credits).
-PASSWORD_XOR_KEY = 0x56789
-PASSWORD_MASK = 0xFFFFFFFF
-UTSXXX_MODULO = 1000
-
-# The controller returns its status in a <ret> element of the ctrl.xml response.
-_RET_PATTERN = re.compile(r"<ret>\s*(-?\d+)\s*</ret>")
 
 class CCM15Device:
     def __init__(self, host: str, port: int, timeout = DEFAULT_TIMEOUT,
@@ -191,7 +184,7 @@ class CCM15Device:
         (wrong password); any other code, or no ``<ret>`` at all, is an accepted
         command, so everything else maps to ``OK``.
         """
-        match = _RET_PATTERN.search(text or "")
+        match = RET_PATTERN.search(text or "")
         if match is None:
             return CCM15ReturnCode.OK
         try:

--- a/ccm15/CCM15Device.py
+++ b/ccm15/CCM15Device.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import re
 import time
 import httpx
 import xmltodict
 from .CCM15DeviceState import CCM15DeviceState
+from .CCM15ReturnCode import CCM15ReturnCode
 from .CCM15SlaveDevice import CCM15SlaveDevice
 from .TriState import TriState
 
@@ -13,6 +15,18 @@ CONF_URL_CTRL = "ctrl.xml"
 DEFAULT_TIMEOUT = 10
 DEFAULT_STATE_TTL = 300
 
+# Password obfuscation, mirroring the controller's own pwdstr() in midea.js.
+# The on-wire `pwd` value is the configured numeric password XORed with a fixed
+# magic key and cast to an unsigned 32-bit integer; a per-request `utsxxx`
+# nonce (milliseconds modulo 1000) is appended. These constants are otherwise
+# undocumented and come from a midea.js capture (see PROTOCOL.md / Credits).
+PASSWORD_XOR_KEY = 0x56789
+PASSWORD_MASK = 0xFFFFFFFF
+UTSXXX_MODULO = 1000
+
+# The controller returns its status in a <ret> element of the ctrl.xml response.
+_RET_PATTERN = re.compile(r"<ret>\s*(-?\d+)\s*</ret>")
+
 class CCM15Device:
     def __init__(self, host: str, port: int, timeout = DEFAULT_TIMEOUT,
                  state_ttl = DEFAULT_STATE_TTL,
@@ -21,10 +35,13 @@ class CCM15Device:
         self.host = host
         self.port = port
         self.timeout = timeout
-        # Some CCM15 firmwares reject control commands unless a 6-digit
-        # password is included as a "pwd" query parameter. When set, it is
-        # prepended to every ctrl.xml URL the library builds; when left as
-        # None the URL is built without it.
+        # Some CCM15 firmwares reject control commands unless the device
+        # password is supplied. Pass the *configured* numeric password exactly
+        # as shown on the controller's settings page (factory default
+        # "123456"). The library applies the same obfuscation the controller's
+        # web UI does (XOR with PASSWORD_XOR_KEY + utsxxx nonce) before putting
+        # it on the wire, so callers never deal with the obfuscated value. When
+        # None, no pwd parameter is sent.
         self.password = password
         # The CCM15 is a flaky embedded bridge: status.xml periodically times
         # out or returns a degraded body (empty, or every slot "-") for up to a
@@ -154,12 +171,48 @@ class CCM15Device:
             return False
         return response.status_code == 200
 
-    async def async_send_state(self, url: str) -> bool:
-        """Send the url to set state to the ccm15 slave."""
-        response = await self._get_client().get(url, timeout=self.timeout)
-        return response.status_code in (httpx.codes.OK, httpx.codes.FOUND)
+    async def async_send_state(self, url: str) -> CCM15ReturnCode:
+        """Send the url to set state to the ccm15 slave.
 
-    async def async_set_state(self, ac_index: int, data) -> bool:
+        Returns a :class:`CCM15ReturnCode`: ``OK`` when the controller accepted
+        the command, ``WRONG_PASSWORD`` when it rejected the ``pwd`` parameter
+        (``<ret>250</ret>``), or ``CONNECTION_ERROR`` on a non-OK HTTP status.
+        """
+        response = await self._get_client().get(url, timeout=self.timeout)
+        if response.status_code not in (httpx.codes.OK, httpx.codes.FOUND):
+            return CCM15ReturnCode.CONNECTION_ERROR
+        return self._parse_return_code(response.text)
+
+    @staticmethod
+    def _parse_return_code(text: str) -> CCM15ReturnCode:
+        """Map a ctrl.xml response body to a CCM15ReturnCode.
+
+        The controller's web UI only treats ``<ret>250</ret>`` as an error
+        (wrong password); any other code, or no ``<ret>`` at all, is an accepted
+        command, so everything else maps to ``OK``.
+        """
+        match = _RET_PATTERN.search(text or "")
+        if match is None:
+            return CCM15ReturnCode.OK
+        try:
+            return CCM15ReturnCode(int(match.group(1)))
+        except ValueError:
+            return CCM15ReturnCode.OK
+
+    def _password_query(self) -> str:
+        """Build the obfuscated `pwd`/`utsxxx` query prefix, or "" if no password.
+
+        Mirrors the controller's pwdstr(): the configured numeric password is
+        XORed with PASSWORD_XOR_KEY, cast to unsigned 32-bit, and paired with a
+        utsxxx nonce (milliseconds modulo UTSXXX_MODULO).
+        """
+        if not self.password:
+            return ""
+        pwd = (int(self.password) ^ PASSWORD_XOR_KEY) & PASSWORD_MASK
+        utsxxx = int(time.time() * 1000) % UTSXXX_MODULO
+        return f"pwd={pwd}&utsxxx={utsxxx}&"
+
+    async def async_set_state(self, ac_index: int, data) -> CCM15ReturnCode:
         """Set new target states.
 
         The controller addresses slaves with a 64-bit mask split across two
@@ -167,6 +220,9 @@ class CCM15Device:
         controller's own cmd_aclist() in midea.js). Previously the whole mask
         was written to ac0, which silently overflowed for slave indices >= 32
         and targeted the wrong unit (or nothing).
+
+        Returns a :class:`CCM15ReturnCode` describing how the controller
+        responded (see :meth:`async_send_state`).
         """
         if ac_index < 32:
             ac0 = 2 ** ac_index
@@ -174,7 +230,7 @@ class CCM15Device:
         else:
             ac0 = 0
             ac1 = 2 ** (ac_index - 32)
-        pwd_part = f"pwd={self.password}&" if self.password else ""
+        pwd_part = self._password_query()
         url = BASE_URL.format(
             self.host,
             self.port,

--- a/ccm15/CCM15ReturnCode.py
+++ b/ccm15/CCM15ReturnCode.py
@@ -1,0 +1,23 @@
+"""Return codes for CCM15 control writes."""
+from enum import IntEnum
+
+
+class CCM15ReturnCode(IntEnum):
+    """Outcome of a ``ctrl.xml`` control write.
+
+    Non-negative values are the controller's own ``<ret>`` codes, as decoded by
+    its web UI (``midea.js``). Negative values are synthetic: they cover
+    outcomes the controller never assigns a code to (for example, the request
+    not completing at the HTTP layer).
+    """
+
+    OK = 0
+    """The controller accepted the command."""
+
+    WRONG_PASSWORD = 250
+    """The controller rejected the command: the ``pwd`` parameter was missing or
+    did not match the configured device password."""
+
+    CONNECTION_ERROR = -1
+    """The request failed or returned a non-OK HTTP status; no ``<ret>`` code
+    was received from the controller."""

--- a/ccm15/__init__.py
+++ b/ccm15/__init__.py
@@ -2,8 +2,15 @@
 
 from .CCM15Device import CCM15Device
 from .CCM15DeviceState import CCM15DeviceState
+from .CCM15ReturnCode import CCM15ReturnCode
 from .CCM15SlaveDevice import CCM15SlaveDevice
 from .TriState import TriState
 
-__all__ = ['CCM15Device', 'CCM15DeviceState', 'CCM15SlaveDevice', 'TriState']
+__all__ = [
+    'CCM15Device',
+    'CCM15DeviceState',
+    'CCM15ReturnCode',
+    'CCM15SlaveDevice',
+    'TriState',
+]
 

--- a/ccm15/const.py
+++ b/ccm15/const.py
@@ -1,0 +1,24 @@
+"""Constants for the CCM15 library."""
+import re
+
+# HTTP endpoints.
+BASE_URL = "http://{0}:{1}/{2}"
+CONF_URL_STATUS = "status.xml"
+CONF_URL_CTRL = "ctrl.xml"
+
+# Defaults.
+DEFAULT_TIMEOUT = 10
+DEFAULT_STATE_TTL = 300
+
+# Password obfuscation, mirroring the controller's own pwdstr() in midea.js.
+# The on-wire `pwd` value is the configured numeric password XORed with a fixed
+# magic key and cast to an unsigned 32-bit integer; a per-request `utsxxx`
+# nonce (milliseconds modulo UTSXXX_MODULO) is appended. These values are
+# otherwise undocumented and come from a midea.js capture (see PROTOCOL.md /
+# Credits).
+PASSWORD_XOR_KEY = 0x56789
+PASSWORD_MASK = 0xFFFFFFFF
+UTSXXX_MODULO = 1000
+
+# The controller returns its status in a <ret> element of the ctrl.xml response.
+RET_PATTERN = re.compile(r"<ret>\s*(-?\d+)\s*</ret>")

--- a/tests/test_ccm15.py
+++ b/tests/test_ccm15.py
@@ -3,7 +3,13 @@ from unittest.mock import patch, MagicMock
 
 import httpx
 
-from ccm15 import CCM15Device, CCM15DeviceState, CCM15SlaveDevice, TriState
+from ccm15 import (
+    CCM15Device,
+    CCM15DeviceState,
+    CCM15ReturnCode,
+    CCM15SlaveDevice,
+    TriState,
+)
 
 
 class TestCCM15(unittest.IsolatedAsyncioTestCase):
@@ -126,10 +132,13 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
         """Slots 0-31 go into ac0, ac1 is 0."""
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.text = ""
         mock_get.return_value = mock_response
 
         data = MagicMock(ac_mode=0, fan_mode=0, temperature_setpoint=24)
-        self.assertTrue(await self.ccm.async_set_state(4, data))
+        self.assertEqual(
+            await self.ccm.async_set_state(4, data), CCM15ReturnCode.OK
+        )
 
         called_url = mock_get.call_args.args[0]
         self.assertIn("ac0=16", called_url)  # 2 ** 4
@@ -140,10 +149,13 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
         """Slots 32-63 go into ac1, ac0 is 0."""
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.text = ""
         mock_get.return_value = mock_response
 
         data = MagicMock(ac_mode=0, fan_mode=0, temperature_setpoint=24)
-        self.assertTrue(await self.ccm.async_set_state(40, data))
+        self.assertEqual(
+            await self.ccm.async_set_state(40, data), CCM15ReturnCode.OK
+        )
 
         called_url = mock_get.call_args.args[0]
         self.assertIn("ac0=0", called_url)
@@ -162,10 +174,13 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
         """
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.text = ""
         mock_get.return_value = mock_response
 
         data = MagicMock(ac_mode=1, fan_mode=2, temperature_setpoint=26)
-        self.assertTrue(await self.ccm.async_set_state(0, data))
+        self.assertEqual(
+            await self.ccm.async_set_state(0, data), CCM15ReturnCode.OK
+        )
 
         called_url = mock_get.call_args.args[0]
         self.assertIn("mode=1", called_url)  # HEAT preserved, not reset to COOL
@@ -173,25 +188,36 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
         self.assertIn("temp=26", called_url)
 
     @patch("httpx.AsyncClient.get")
-    async def test_set_state_url_includes_password(self, mock_get):
-        """When a password is configured, the ctrl.xml URL carries pwd=."""
+    async def test_set_state_url_obfuscates_password(self, mock_get):
+        """The configured password is XOR-obfuscated on the wire, with a nonce.
+
+        The factory default 123456 must go out as pwd=296393
+        (0x1E240 ^ 0x56789 = 0x485C9 = 296393), matching the controller's own
+        pwdstr(). The user-facing value (123456) must never appear in the URL.
+        """
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.text = ""
         mock_get.return_value = mock_response
 
         device = CCM15Device("localhost", 8000, password="123456")
         data = MagicMock(ac_mode=0, fan_mode=4, temperature_setpoint=22)
-        self.assertTrue(await device.async_set_state(1, data))
+        self.assertEqual(
+            await device.async_set_state(1, data), CCM15ReturnCode.OK
+        )
 
         called_url = mock_get.call_args.args[0]
-        self.assertIn("pwd=123456", called_url)
+        self.assertIn("pwd=296393", called_url)
+        self.assertNotIn("pwd=123456", called_url)  # raw value never sent
+        self.assertIn("utsxxx=", called_url)  # nonce included
         self.assertIn("ac0=2", called_url)  # 2 ** 1
 
     @patch("httpx.AsyncClient.get")
     async def test_set_state_url_omits_password_when_unset(self, mock_get):
-        """Without a password the URL must not include a pwd parameter."""
+        """Without a password the URL must not include pwd or utsxxx."""
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.text = ""
         mock_get.return_value = mock_response
 
         device = CCM15Device("localhost", 8000)
@@ -200,6 +226,36 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
 
         called_url = mock_get.call_args.args[0]
         self.assertNotIn("pwd=", called_url)
+        self.assertNotIn("utsxxx=", called_url)
+
+    @patch("httpx.AsyncClient.get")
+    async def test_set_state_returns_wrong_password(self, mock_get):
+        """A <ret>250</ret> response maps to CCM15ReturnCode.WRONG_PASSWORD."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "<response><ret>250</ret></response>"
+        mock_get.return_value = mock_response
+
+        device = CCM15Device("localhost", 8000, password="999999")
+        data = MagicMock(ac_mode=0, fan_mode=0, temperature_setpoint=24)
+        self.assertEqual(
+            await device.async_set_state(0, data),
+            CCM15ReturnCode.WRONG_PASSWORD,
+        )
+
+    @patch("httpx.AsyncClient.get")
+    async def test_set_state_returns_connection_error_on_bad_status(self, mock_get):
+        """A non-OK HTTP status maps to CCM15ReturnCode.CONNECTION_ERROR."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = ""
+        mock_get.return_value = mock_response
+
+        data = MagicMock(ac_mode=0, fan_mode=0, temperature_setpoint=24)
+        self.assertEqual(
+            await self.ccm.async_set_state(0, data),
+            CCM15ReturnCode.CONNECTION_ERROR,
+        )
 
     async def test_uses_injected_client_when_provided(self) -> None:
         """A client passed to the constructor is reused instead of building a new one."""
@@ -246,6 +302,7 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
         """A freshly decoded device has desired_swing UNSET, so no sw is sent."""
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.text = ""
         mock_get.return_value = mock_response
 
         data = CCM15SlaveDevice(bytes.fromhex("00000001020304"))
@@ -260,6 +317,7 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
         """Setting desired_swing=ON emits sw=1."""
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.text = ""
         mock_get.return_value = mock_response
 
         data = CCM15SlaveDevice(bytes.fromhex("00000001020304"))
@@ -274,6 +332,7 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
         """Setting desired_swing=OFF emits sw=0."""
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.text = ""
         mock_get.return_value = mock_response
 
         data = CCM15SlaveDevice(bytes.fromhex("00000001020304"))
@@ -288,6 +347,7 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
         """A freshly decoded device has desired_heater UNSET, so no ht is sent."""
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.text = ""
         mock_get.return_value = mock_response
 
         data = CCM15SlaveDevice(bytes.fromhex("00000001020304"))
@@ -302,6 +362,7 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
         """Setting desired_heater=ON emits ht=1, independent of swing."""
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.text = ""
         mock_get.return_value = mock_response
 
         data = CCM15SlaveDevice(bytes.fromhex("00000001020304"))
@@ -317,6 +378,7 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
         """Setting desired_heater=OFF emits ht=0."""
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.text = ""
         mock_get.return_value = mock_response
 
         data = CCM15SlaveDevice(bytes.fromhex("00000001020304"))

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -9,7 +9,7 @@ from unittest.mock import patch, MagicMock
 
 import httpx
 
-from ccm15 import CCM15Device
+from ccm15 import CCM15Device, CCM15ReturnCode
 
 
 class TestAsyncSendState(unittest.IsolatedAsyncioTestCase):
@@ -17,19 +17,41 @@ class TestAsyncSendState(unittest.IsolatedAsyncioTestCase):
         self.ccm = CCM15Device("localhost", 8000)
 
     @patch("httpx.AsyncClient.get")
-    async def test_returns_true_on_ok(self, mock_get):
-        mock_get.return_value = MagicMock(status_code=httpx.codes.OK)
-        self.assertTrue(await self.ccm.async_send_state("http://x/ctrl.xml"))
+    async def test_returns_ok_on_ok(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=httpx.codes.OK, text="")
+        self.assertEqual(
+            await self.ccm.async_send_state("http://x/ctrl.xml"),
+            CCM15ReturnCode.OK,
+        )
 
     @patch("httpx.AsyncClient.get")
-    async def test_returns_true_on_found(self, mock_get):
-        mock_get.return_value = MagicMock(status_code=httpx.codes.FOUND)
-        self.assertTrue(await self.ccm.async_send_state("http://x/ctrl.xml"))
+    async def test_returns_ok_on_found(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=httpx.codes.FOUND, text="")
+        self.assertEqual(
+            await self.ccm.async_send_state("http://x/ctrl.xml"),
+            CCM15ReturnCode.OK,
+        )
 
     @patch("httpx.AsyncClient.get")
-    async def test_returns_false_on_error_status(self, mock_get):
-        mock_get.return_value = MagicMock(status_code=httpx.codes.INTERNAL_SERVER_ERROR)
-        self.assertFalse(await self.ccm.async_send_state("http://x/ctrl.xml"))
+    async def test_returns_connection_error_on_error_status(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=httpx.codes.INTERNAL_SERVER_ERROR, text=""
+        )
+        self.assertEqual(
+            await self.ccm.async_send_state("http://x/ctrl.xml"),
+            CCM15ReturnCode.CONNECTION_ERROR,
+        )
+
+    @patch("httpx.AsyncClient.get")
+    async def test_returns_wrong_password_on_ret_250(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=httpx.codes.OK,
+            text="<response><ret>250</ret></response>",
+        )
+        self.assertEqual(
+            await self.ccm.async_send_state("http://x/ctrl.xml"),
+            CCM15ReturnCode.WRONG_PASSWORD,
+        )
 
 
 class TestAsyncTestConnection(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION

## Summary

Implements the password obfuscation and return-code surfacing from #54.

### Password is now the configured value (breaking)

Callers pass the **configured** numeric device password (the value on the
controller's settings page; factory default `123456`). The library applies the
controller's own `pwdstr()` transform before sending it:

```
pwd_on_wire = (configured_password XOR 0x56789) & 0xFFFFFFFF
utsxxx      = milliseconds_since_epoch % 1000
```

So `123456` goes on the wire as `pwd=296393`. Users no longer have to open
DevTools and copy the obfuscated value off a `ctrl.xml` request.

> **Correction to #54:** the worked example there had an arithmetic slip —
> `0x1E240 ^ 0x56789 = 0x485C9 = 296393`, not `0x495A9 = 300457`. The code and
> docs here use the correct value (verified by the new test).

### Proper return codes (breaking)

`async_set_state` / `async_send_state` now return a **`CCM15ReturnCode`**
`IntEnum` instead of `bool`:

| Member | Value | Meaning |
|--------|-------|---------|
| `OK` | `0` | Controller accepted the command |
| `WRONG_PASSWORD` | `250` | Controller's `<ret>250</ret>` — bad/missing password |
| `CONNECTION_ERROR` | `-1` | Non-OK HTTP status / no response |

Values are the controller's real `<ret>` codes (negative = synthetic), so callers
can tell a rejected password from a transport failure.

### Other

- Magic numbers are named constants in `ccm15/const.py` (`PASSWORD_XOR_KEY`, `PASSWORD_MASK`, `UTSXXX_MODULO`).
- `PROTOCOL.md` documents the `pwd`/`utsxxx` transform and `<ret>` codes; credited
  to @Alexa-RR's `midea.js` capture (the `0x56789` key is undocumented anywhere else).
- 42 tests pass, including XOR value, nonce presence, password omission, and each return code.

## Breaking changes

- `password` now means the **configured** value, not the pre-obfuscated URL value.
- Write helpers return `CCM15ReturnCode`, not `bool`.

The only known downstream caller (home-assistant/core#173804) is draft-only and
will adopt the new contract; releasing as **1.0.0** (`Release-As: 1.0.0`).

Fixes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)
