### PR TITLE
ci: publish to PyPI via OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,8 +31,12 @@ jobs:
     # same run, gated on release-please having actually cut a release.
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/py_ccm15
     permissions:
       contents: read
+      id-token: write   # OIDC for PyPI Trusted Publishing (no API token needed)
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -45,13 +49,14 @@ jobs:
       - name: Install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build twine
+          pip install build
 
       - name: Build package
         run: python -m build
 
       - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: twine upload dist/*
+        # Trusted Publishing (OIDC) — no API token. Requires a PyPI trusted
+        # publisher for project py_ccm15: owner HomeOps, repo py-ccm15,
+        # workflow release-please.yml, environment pypi. Emits PEP 740
+        # provenance attestations by default.
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

Switch the PyPI publish step from `twine` + a static `PYPI_API_TOKEN` to
**OIDC Trusted Publishing** via `pypa/gh-action-pypi-publish`.

- Adds `id-token: write` and a `pypi` GitHub environment to the `publish` job.
- Removes the `twine` install and the `PYPI_API_TOKEN` secret usage.
- Emits **PEP 740 provenance attestations** by default.

This clears the supply-chain warnings raised by Home Assistant's
`Check requirements` workflow (no CI provenance attestation; publishing via a
static token rather than OIDC) — see home-assistant/core#174099.

## Required PyPI setup (already configured)

A PyPI trusted publisher must exist for the project:

- **Project:** `py_ccm15`
- **Owner:** `HomeOps`
- **Repository:** `py-ccm15`
- **Workflow:** `release-please.yml`
- **Environment:** `pypi`

## Notes

- Affects **future** releases only; published versions are unchanged.
- The `PYPI_API_TOKEN` secret can be deleted after this merges.
