### PR TITLE
fix: use auto fan for active commands with fan off

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -131,6 +131,10 @@ controller treats every `ctrl.xml` write as the complete desired state**: any
 field that is *not* sent is reset to the firmware's default (which, for mode,
 lands on COOL). A single write must therefore always carry the mode, fan and
 temperature it wants to keep — see the regression behavior in issue #15.
+When the target mode is active but the decoded fan state is `Off`, this library
+sends `fan=Auto` instead; some CCM15 firmwares do not start a unit from an
+active mode command that also carries `fan=Off`. Commands whose target mode is
+`Off` still preserve `fan=Off`.
 
 ```
 http://<host>:<port>/ctrl.xml?[pwd=<obf>&utsxxx=<nonce>&]ac0=<mask>&ac1=<mask>&mode=<m>&fan=<f>&temp=<t>[&sw=<0|1>][&ht=<0|1>]

--- a/ccm15/CCM15Device.py
+++ b/ccm15/CCM15Device.py
@@ -8,11 +8,14 @@ from .CCM15ReturnCode import CCM15ReturnCode
 from .CCM15SlaveDevice import CCM15SlaveDevice
 from .TriState import TriState
 from .const import (
+    AC_MODE_OFF,
     BASE_URL,
     CONF_URL_CTRL,
     CONF_URL_STATUS,
     DEFAULT_STATE_TTL,
     DEFAULT_TIMEOUT,
+    FAN_MODE_AUTO,
+    FAN_MODE_OFF,
     PASSWORD_MASK,
     PASSWORD_XOR_KEY,
     RET_PATTERN,
@@ -205,6 +208,13 @@ class CCM15Device:
         utsxxx = int(time.time() * 1000) % UTSXXX_MODULO
         return f"pwd={pwd}&utsxxx={utsxxx}&"
 
+    @staticmethod
+    def _fan_mode_for_command(ac_mode: int, fan_mode: int) -> int:
+        """Return a runnable fan mode for the target HVAC command."""
+        if ac_mode != AC_MODE_OFF and fan_mode == FAN_MODE_OFF:
+            return FAN_MODE_AUTO
+        return fan_mode
+
     async def async_set_state(self, ac_index: int, data) -> CCM15ReturnCode:
         """Set new target states.
 
@@ -224,6 +234,7 @@ class CCM15Device:
             ac0 = 0
             ac1 = 2 ** (ac_index - 32)
         pwd_part = self._password_query()
+        fan_mode = self._fan_mode_for_command(data.ac_mode, data.fan_mode)
         url = BASE_URL.format(
             self.host,
             self.port,
@@ -234,7 +245,7 @@ class CCM15Device:
             + "&ac1="
             + str(ac1)
             + "&mode=" + str(data.ac_mode)
-            +  "&fan=" + str(data.fan_mode)
+            + "&fan=" + str(fan_mode)
             + "&temp=" + str(data.temperature_setpoint)
         )
         # Opt-in swing: only emit `sw` when the caller set a desired value.

--- a/ccm15/const.py
+++ b/ccm15/const.py
@@ -10,6 +10,11 @@ CONF_URL_CTRL = "ctrl.xml"
 DEFAULT_TIMEOUT = 10
 DEFAULT_STATE_TTL = 300
 
+# Mode and fan command codes.
+AC_MODE_OFF = 4
+FAN_MODE_AUTO = 0
+FAN_MODE_OFF = 5
+
 # Password obfuscation, mirroring the controller's own pwdstr() in midea.js.
 # The on-wire `pwd` value is the configured numeric password XORed with a fixed
 # magic key and cast to an unsigned 32-bit integer; a per-request `utsxxx`

--- a/tests/test_ccm15.py
+++ b/tests/test_ccm15.py
@@ -188,6 +188,50 @@ class TestCCM15(unittest.IsolatedAsyncioTestCase):
         self.assertIn("temp=26", called_url)
 
     @patch("httpx.AsyncClient.get")
+    async def test_async_set_state_active_mode_uses_auto_fan_when_fan_off(
+        self, mock_get
+    ):
+        """An active mode with fan off is sent with auto fan.
+
+        The controller treats each write as the complete desired state. Some
+        firmwares do not start an active HVAC mode when the same command also
+        carries fan=off, so the library normalizes that wire command to
+        fan=auto.
+        """
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = ""
+        mock_get.return_value = mock_response
+
+        data = MagicMock(ac_mode=0, fan_mode=5, temperature_setpoint=26)
+        self.assertEqual(
+            await self.ccm.async_set_state(0, data), CCM15ReturnCode.OK
+        )
+
+        called_url = mock_get.call_args.args[0]
+        self.assertIn("mode=0", called_url)
+        self.assertIn("fan=0", called_url)
+        self.assertIn("temp=26", called_url)
+        self.assertEqual(data.fan_mode, 5)
+
+    @patch("httpx.AsyncClient.get")
+    async def test_async_set_state_off_mode_preserves_fan_off(self, mock_get):
+        """An off command can still carry fan off."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = ""
+        mock_get.return_value = mock_response
+
+        data = MagicMock(ac_mode=4, fan_mode=5, temperature_setpoint=26)
+        self.assertEqual(
+            await self.ccm.async_set_state(0, data), CCM15ReturnCode.OK
+        )
+
+        called_url = mock_get.call_args.args[0]
+        self.assertIn("mode=4", called_url)
+        self.assertIn("fan=5", called_url)
+
+    @patch("httpx.AsyncClient.get")
     async def test_set_state_url_obfuscates_password(self, mock_get):
         """The configured password is XOR-obfuscated on the wire, with a nonce.
 


### PR DESCRIPTION
## Summary

Fixes HomeOps/py-ccm15#59.

`CCM15Device.async_set_state()` now normalizes the wire command when a caller sends an active HVAC mode with `fan_mode=Off`. In that case, the library sends `fan=Auto` so the CCM15 receives a runnable complete target state.

Commands whose target mode is `Off` still preserve `fan=Off`.

## Changes

- Add mode/fan command constants for `Off` and `Auto`.
- Normalize `fan=Off` to `fan=Auto` only when `ac_mode` is not `Off`.
- Keep the caller's `data.fan_mode` unchanged; only the emitted `ctrl.xml` command is adjusted.
- Add tests for:
  - active mode + fan off emits `fan=0`
  - off mode + fan off still emits `fan=5`
- Document the behavior in `PROTOCOL.md`.

## Validation

- `python -m pytest -q`
- `python -m pytest -q --cov=ccm15 --cov-branch --cov-report=term-missing --cov-fail-under=95`
- `python -m build`